### PR TITLE
Lower .NET Standard reference version to 1.0

### DIFF
--- a/NCrontab.Advanced/Properties/AssemblyInfo.cs
+++ b/NCrontab.Advanced/Properties/AssemblyInfo.cs
@@ -20,7 +20,9 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
+#if !NETSTANDARD1_0
 [assembly: Guid("d56bc51a-e8f9-4911-8c4c-eab2763699cd")]
+#endif
 
 // Version information for an assembly consists of the following four values:
 //

--- a/NCrontab.Advanced/project.json
+++ b/NCrontab.Advanced/project.json
@@ -1,10 +1,7 @@
 {
   "version": "1.2.3-*",
-  "runtimes": { 
-    "win": { }
-  },
   "frameworks": {
-    "netstandard1.6": {
+    "netstandard1.0": {
       "dependencies": {
         "NETStandard.Library": "1.6.0"
       },


### PR DESCRIPTION
For libraries it's essential to support as many platforms as possible. This PR allows NCrontab.Advanced to be referenced from libraries that doesn't support .NET Standard 1.6.