### PR TITLE
Add properties to the csproj that were previously in the nuspec file

### DIFF
--- a/NCrontab.Advanced/NCrontab.Advanced.csproj
+++ b/NCrontab.Advanced/NCrontab.Advanced.csproj
@@ -21,6 +21,12 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
+    <Authors>jcoutch</Authors>
+    <PackageLicenseUrl>https://github.com/jcoutch/NCrontab-Advanced/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/jcoutch/NCrontab-Advanced</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/jcoutch/NCrontab-Advanced/master/NCrontab.Advanced/Icons/x-office-calendar.png</PackageIconUrl>
+    <PackageTags>cron crontab ncrontab schedule dates datetime</PackageTags>
+    <PackageDescription>NCrontab-Advanced is intended to be as close of a drop-in replacement for NCrontab as possible, and contains additional features (#, L, W support, as well as support for seconds and years.)</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">


### PR DESCRIPTION
The [nuget package that is currently on nuget.org](https://www.nuget.org/packages/NCrontab.Advanced/1.3.15) doesn't have the project url, license url and other properties set.

(I found this putting together some stuff to track license dependencies on our code)

I _believe_ this is due to the change in how this has been built - it no longer uses the nuspec file to set these properties. I wasn't 100% sure how it was being built, so I didn't delete the nuspec file.

before:
![image](https://user-images.githubusercontent.com/373389/48244513-3ef0ba80-e43a-11e8-9fa5-dec61fbb09fa.png)

after:
![image](https://user-images.githubusercontent.com/373389/48244549-6fd0ef80-e43a-11e8-8c21-7e57f4cda6a9.png)

Side note - the statement in the readme
> NOTE - If you're building via dotnet, make sure you either comment out the net35 section in project.json...

is no longer accurate. DIdn't want to mix it up with this PR though.