### PR TITLE
Correctly roll over to last hour in range

### DIFF
--- a/NCrontab.Advanced.Tests/CronInstanceTests.cs
+++ b/NCrontab.Advanced.Tests/CronInstanceTests.cs
@@ -277,6 +277,7 @@ namespace NCrontab.Advanced.Tests
                 new { startTime = "20/12/2003 10:00:00", inputString = " * 3/4 * * *", nextOccurence = "20/12/2003 11:00:00", cronStringFormat = CronStringFormat.Default },
                 new { startTime = "20/12/2003 00:30:00", inputString = " * 3   * * *", nextOccurence = "20/12/2003 03:00:00", cronStringFormat = CronStringFormat.Default },
                 new { startTime = "20/12/2003 01:45:00", inputString = "30 3   * * *", nextOccurence = "20/12/2003 03:30:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "20/12/2003 22:55:00", inputString = "*/15 9-23 * * *", nextOccurence = "20/12/2003 23:00:00", cronStringFormat = CronStringFormat.Default },
 
                 // Day of month tests
 

--- a/NCrontab.Advanced/Filters/RangeFilter.cs
+++ b/NCrontab.Advanced/Filters/RangeFilter.cs
@@ -100,7 +100,7 @@ namespace NCrontab.Advanced.Filters
             while (newValue < max && !IsMatch(newValue.Value))
                 newValue++;
 
-            if (newValue >= max) newValue = null;
+            if (newValue > max) newValue = null;
 
             return newValue;
         }


### PR DESCRIPTION
This fixes a bug where incrementing the hour from say 10pm to 11pm (the last increment in a range as specified in a hour range such as 9-23) skips over the last hour (11pm) and goes straight to 9am the following day.