### PR TITLE
Do not skip hour 23 when using hour step

### DIFF
--- a/NCrontab.Advanced.Tests/CronInstanceTests.cs
+++ b/NCrontab.Advanced.Tests/CronInstanceTests.cs
@@ -644,6 +644,123 @@ namespace NCrontab.Advanced.Tests
             Assert.IsFalse(stopWatch.ElapsedMilliseconds > 250, string.Format("Elapsed time should not exceed 250ms (was {0} ms)", stopWatch.ElapsedMilliseconds));
         }
 
+        [TestMethod]
+        public void EveryHour()
+        {
+            var cron = CrontabSchedule.Parse("0 * * * *");
+            var start = DateTime.Today.ToUniversalTime();
+            var currentTime = start;
+            foreach (var nextOccurrence in cron.GetNextOccurrences(start,start.AddDays(2)))
+            {
+                currentTime = currentTime.AddHours(1);
+                Assert.AreEqual(currentTime, nextOccurrence);
+            }
+        }
+        
+        [TestMethod]
+        public void EveryMinute()
+        {
+            var cron = CrontabSchedule.Parse("* * * * *");
+            var start = DateTime.Today.ToUniversalTime();
+            var currentTime = start;
+            foreach (var nextOccurrence in cron.GetNextOccurrences(start, start.AddHours(2)))
+            {
+                currentTime = currentTime.AddMinutes(1);
+                Assert.AreEqual(currentTime, nextOccurrence);
+            }
+        }
+
+        [TestMethod]
+        public void EverySecond()
+        {
+            var cron = CrontabSchedule.Parse("* * * * * *", CronStringFormat.WithSeconds);
+            var start = DateTime.Today.ToUniversalTime();
+            var currentTime = start;
+            foreach (var nextOccurrence in cron.GetNextOccurrences(start, start.AddMinutes(2)))
+            {
+                currentTime = currentTime.AddSeconds(1);
+                Assert.AreEqual(currentTime, nextOccurrence);
+            }
+        }
+
+        [TestMethod]
+        public void EveryHour_Step()
+        {
+            var cron = CrontabSchedule.Parse("0 0/1 * * *");
+            var start = DateTime.Today.ToUniversalTime();
+            var currentTime = start;
+            foreach (var nextOccurrence in cron.GetNextOccurrences(start, start.AddDays(2)))
+            {
+                currentTime = currentTime.AddHours(1);
+                Assert.AreEqual(currentTime, nextOccurrence);
+            }
+        }
+
+        [TestMethod]
+        public void EveryMinute_Step()
+        {
+            var cron = CrontabSchedule.Parse("0/1 * * * *");
+            var start = DateTime.Today.ToUniversalTime();
+            var currentTime = start;
+            foreach (var nextOccurrence in cron.GetNextOccurrences(start, start.AddHours(2)))
+            {
+                currentTime = currentTime.AddMinutes(1);
+                Assert.AreEqual(currentTime, nextOccurrence);
+            }
+        }
+
+        [TestMethod]
+        public void EverySecond_Step()
+        {
+            var cron = CrontabSchedule.Parse("0/1 * * * * *", CronStringFormat.WithSeconds);
+            var start = DateTime.Today.ToUniversalTime();
+            var currentTime = start;
+            foreach (var nextOccurrence in cron.GetNextOccurrences(start, start.AddMinutes(2)))
+            {
+                currentTime = currentTime.AddSeconds(1);
+                Assert.AreEqual(currentTime, nextOccurrence);
+            }
+        }
+
+        [TestMethod]
+        public void EveryHour_Range()
+        {
+            var cron = CrontabSchedule.Parse("0 0-23 * * *");
+            var start = DateTime.Today.ToUniversalTime();
+            var currentTime = start;
+            foreach (var nextOccurrence in cron.GetNextOccurrences(start, start.AddDays(2)))
+            {
+                currentTime = currentTime.AddHours(1);
+                Assert.AreEqual(currentTime, nextOccurrence);
+            }
+        }
+
+        [TestMethod]
+        public void EveryMinute_Range()
+        {
+            var cron = CrontabSchedule.Parse("0-59 * * * *");
+            var start = DateTime.Today.ToUniversalTime();
+            var currentTime = start;
+            foreach (var nextOccurrence in cron.GetNextOccurrences(start, start.AddHours(2)))
+            {
+                currentTime = currentTime.AddMinutes(1);
+                Assert.AreEqual(currentTime, nextOccurrence);
+            }
+        }
+
+        [TestMethod]
+        public void EverySecond_Range()
+        {
+            var cron = CrontabSchedule.Parse("0-59 * * * * *", CronStringFormat.WithSeconds);
+            var start = DateTime.Today.ToUniversalTime();
+            var currentTime = start;
+            foreach (var nextOccurrence in cron.GetNextOccurrences(start, start.AddMinutes(2)))
+            {
+                currentTime = currentTime.AddSeconds(1);
+                Assert.AreEqual(currentTime, nextOccurrence);
+            }
+        }
+
         static void CronCall(string startTimeString, string cronExpression, string nextTimeString, CronStringFormat format)
         {
             var schedule = CrontabSchedule.Parse(cronExpression, format);

--- a/NCrontab.Advanced/Filters/StepFilter.cs
+++ b/NCrontab.Advanced/Filters/StepFilter.cs
@@ -100,7 +100,7 @@ namespace NCrontab.Advanced.Filters
             while (newValue < max && !IsMatch(newValue.Value))
                 newValue++;
 
-            if (newValue >= max) newValue = null;
+            if (newValue > max) newValue = null;
 
             return newValue;
         }


### PR DESCRIPTION
Update to avoid skipping the last hour 23 when using an interval in the hour component (e.g. * 0/1 * * *). This also covers minute and second components, so that 59 is not omitted.