### PR TITLE
Used `ToUpperInvariant` so it doesn't run afoul of different culture settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,3 +238,4 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+.idea/

--- a/NCrontab.Advanced.Tests/CronInstanceTests.cs
+++ b/NCrontab.Advanced.Tests/CronInstanceTests.cs
@@ -513,7 +513,6 @@ namespace NCrontab.Advanced.Tests
             BadField("* * 30-31 Feb *", CronStringFormat.Default);
         }
 
-        [TestMethod]
         static void BadField(string expression, CronStringFormat format)
         {
             Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse(expression, format));

--- a/NCrontab.Advanced.Tests/CronInstanceTests.cs
+++ b/NCrontab.Advanced.Tests/CronInstanceTests.cs
@@ -425,7 +425,14 @@ namespace NCrontab.Advanced.Tests
                 new { startTime = "28/02/2003 12:01:00", inputString = "1 12 28 2 *", nextOccurence = "28/02/2004 12:01:00", previousOccurence="28/02/2002 12:01:00", cronStringFormat = CronStringFormat.Default },
                 new { startTime = "29/02/2004 12:01:00", inputString = "1 12 28 2 *", nextOccurence = "28/02/2005 12:01:00", previousOccurence="28/02/2004 12:01:00", cronStringFormat = CronStringFormat.Default },
 
-                // ? filter  tests
+                //// Specific time tests - December 6 2019 at 3am
+
+                new { startTime = "01/07/1984 00:00:00", inputString = "0 0 3 6 DEC ? 2019", nextOccurence = "06/12/2019 03:00:00", previousOccurence="01/01/0001 00:00:00", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "06/11/2019 00:00:00", inputString = "0 0 3 6 DEC ? 2019", nextOccurence = "06/12/2019 03:00:00", previousOccurence="01/01/0001 00:00:00", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "05/12/2019 00:00:00", inputString = "0 0 3 6 DEC ? 2019", nextOccurence = "06/12/2019 03:00:00", previousOccurence="01/01/0001 00:00:00", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "06/12/2019 02:13:05", inputString = "0 0 3 6 DEC ? 2019", nextOccurence = "06/12/2019 03:00:00", previousOccurence="01/01/0001 00:00:00", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "06/12/2019 12:00:00", inputString = "0 0 3 6 DEC ? 2019", nextOccurence = "31/12/9999 23:59:59", previousOccurence="06/12/2019 03:00:00", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/07/2020 00:00:00", inputString = "0 0 3 6 DEC ? 2019", nextOccurence = "31/12/9999 23:59:59", previousOccurence="06/12/2019 03:00:00", cronStringFormat = CronStringFormat.WithSecondsAndYears },
             };
 
             foreach (var test in tests)

--- a/NCrontab.Advanced.Tests/CronInstanceTests.cs
+++ b/NCrontab.Advanced.Tests/CronInstanceTests.cs
@@ -278,6 +278,8 @@ namespace NCrontab.Advanced.Tests
                 new { startTime = "20/12/2003 00:30:00", inputString = " * 3   * * *", nextOccurence = "20/12/2003 03:00:00", previousOccurence = "19/12/2003 03:59:00", cronStringFormat = CronStringFormat.Default },
                 new { startTime = "20/12/2003 01:45:00", inputString = "30 3   * * *", nextOccurence = "20/12/2003 03:30:00", previousOccurence = "19/12/2003 03:30:00", cronStringFormat = CronStringFormat.Default },
                 new { startTime = "20/12/2003 22:55:00", inputString = "*/15 9-23 * * *", nextOccurence = "20/12/2003 23:00:00", previousOccurence = "20/12/2003 22:45:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "20/12/2003 09:00:00", inputString = "*/59 * * * *", nextOccurence = "20/12/2003 09:59:00", previousOccurence = "20/12/2003 08:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "20/12/2003 09:01:00", inputString = "*/20 * * * *", nextOccurence = "20/12/2003 09:20:00", previousOccurence = "20/12/2003 09:00:00", cronStringFormat = CronStringFormat.Default },
 
                 //// Day of month tests
 

--- a/NCrontab.Advanced.Tests/CronInstanceTests.cs
+++ b/NCrontab.Advanced.Tests/CronInstanceTests.cs
@@ -65,59 +65,59 @@ namespace NCrontab.Advanced.Tests
             Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * * * * * * *", CronStringFormat.WithSecondsAndYears));
         }
 
-	    [TestMethod]
-	    public void OutOfBoundsValues()
-	    {
-			Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("-1 * * * * *", CronStringFormat.WithSeconds));
-			Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("60 * * * * *", CronStringFormat.WithSeconds));
+        [TestMethod]
+        public void OutOfBoundsValues()
+        {
+            Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("-1 * * * * *", CronStringFormat.WithSeconds));
+            Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("60 * * * * *", CronStringFormat.WithSeconds));
 
-			Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * * * * 0", CronStringFormat.WithYears));
-			Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * * * * 10000", CronStringFormat.WithYears));
+            Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * * * * 0", CronStringFormat.WithYears));
+            Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * * * * 10000", CronStringFormat.WithYears));
 
-			Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("-1 * * * *", CronStringFormat.Default));
-			Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("60 * * * *", CronStringFormat.Default));
+            Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("-1 * * * *", CronStringFormat.Default));
+            Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("60 * * * *", CronStringFormat.Default));
 
-			Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* -1 * * *", CronStringFormat.Default));
-			Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* 24 * * *", CronStringFormat.Default));
+            Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* -1 * * *", CronStringFormat.Default));
+            Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* 24 * * *", CronStringFormat.Default));
 
-			Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * 0 * *", CronStringFormat.Default));
-			Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * 32 * *", CronStringFormat.Default));
+            Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * 0 * *", CronStringFormat.Default));
+            Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * 32 * *", CronStringFormat.Default));
 
-			Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * * 0 *", CronStringFormat.Default));
-			Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * * 13 *", CronStringFormat.Default));
+            Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * * 0 *", CronStringFormat.Default));
+            Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * * 13 *", CronStringFormat.Default));
 
-			Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * * * -1", CronStringFormat.Default));
-			Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * * * 8", CronStringFormat.Default));
-		}
+            Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * * * -1", CronStringFormat.Default));
+            Assert2.Throws<CrontabException>(() => CrontabSchedule.Parse("* * * * 8", CronStringFormat.Default));
+        }
 
-	    [TestMethod]
-	    public void SundayProcessesCorrectly()
-	    {
-			var tests = new[]
-			{
-				new { startTime = "01/01/2016 00:00:00", inputString = "0 0 * * 0", nextOccurence = "03/01/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
-				new { startTime = "01/01/2016 00:00:00", inputString = "0 0 * * 7", nextOccurence = "03/01/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
-			};
+        [TestMethod]
+        public void SundayProcessesCorrectly()
+        {
+            var tests = new[]
+            {
+                new { startTime = "01/01/2016 00:00:00", inputString = "0 0 * * 0", nextOccurence = "03/01/2016 00:00:00", previousOccurence= "27/12/2015 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2016 00:00:00", inputString = "0 0 * * 7", nextOccurence = "03/01/2016 00:00:00", previousOccurence= "27/12/2015 00:00:00", cronStringFormat = CronStringFormat.Default },
+            };
 
-			foreach (var test in tests)
-				CronCall(test.startTime, test.inputString, test.nextOccurence, test.cronStringFormat);
-		}
+            foreach (var test in tests)
+                CronCall(test.startTime, test.inputString, test.nextOccurence, test.previousOccurence, test.cronStringFormat);
+        }
 
         [TestMethod]
         public void ThirtyFirstWeekdayForMonthsWithLessThanThirtyDaysProcessesCorrectly()
         {
             var tests = new[]
             {
-                new { startTime = "31/03/2016 00:00:00", inputString = "0 0 31W * *", nextOccurence = "31/05/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2016 00:00:00", inputString = "0 0 31W * *", nextOccurence = "29/01/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/02/2016 00:00:00", inputString = "0 0 31W * *", nextOccurence = "31/03/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/02/2016 00:00:00", inputString = "0 0 30W * *", nextOccurence = "30/03/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/02/2016 00:00:00", inputString = "0 0 29W * *", nextOccurence = "29/02/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/02/2017 00:00:00", inputString = "0 0 29W * *", nextOccurence = "29/03/2017 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "31/03/2016 00:00:00", inputString = "0 0 31W * *", nextOccurence = "31/05/2016 00:00:00", previousOccurence= "29/01/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2016 00:00:00", inputString = "0 0 31W * *", nextOccurence = "29/01/2016 00:00:00", previousOccurence= "31/12/2015 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/02/2016 00:00:00", inputString = "0 0 31W * *", nextOccurence = "31/03/2016 00:00:00", previousOccurence= "29/01/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/02/2016 00:00:00", inputString = "0 0 30W * *", nextOccurence = "30/03/2016 00:00:00", previousOccurence= "29/01/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/02/2016 00:00:00", inputString = "0 0 29W * *", nextOccurence = "29/02/2016 00:00:00", previousOccurence= "29/01/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/02/2017 00:00:00", inputString = "0 0 29W * *", nextOccurence = "29/03/2017 00:00:00", previousOccurence= "30/01/2017 00:00:00", cronStringFormat = CronStringFormat.Default },
             };
 
             foreach (var test in tests)
-                CronCall(test.startTime, test.inputString, test.nextOccurence, test.cronStringFormat);
+                CronCall(test.startTime, test.inputString, test.nextOccurence, test.previousOccurence, test.cronStringFormat);
         }
 
         [TestMethod]
@@ -131,13 +131,13 @@ namespace NCrontab.Advanced.Tests
         {
             var tests = new[] {
                 new { inputString = "* 1-2,3 * * *"                   , outputString = "* 1-2,3 * * *"                   , cronStringFormat = CronStringFormat.Default },
-	            new { inputString = "* * * */2 *"                     , outputString = "* * * */2 *"                     , cronStringFormat = CronStringFormat.Default },
-	            new { inputString = "10-40/15 * * * *"                , outputString = "10-40/15 * * * *"                , cronStringFormat = CronStringFormat.Default },
-	            new { inputString = "* * * Mar,Jan,Aug Fri,Mon-Tue"   , outputString = "* * * 3,1,8 5,1-2"               , cronStringFormat = CronStringFormat.Default },
-	            new { inputString = "1 * 1-2,3 * * *"                 , outputString = "1 * 1-2,3 * * *"                 , cronStringFormat = CronStringFormat.WithSeconds },
-	            new { inputString = "22 * * * */2 *"                  , outputString = "22 * * * */2 *"                  , cronStringFormat = CronStringFormat.WithSeconds },
-	            new { inputString = "33 10-40/15 * * * *"             , outputString = "33 10-40/15 * * * *"             , cronStringFormat = CronStringFormat.WithSeconds },
-	            new { inputString = "55 * * * Mar,Jan,Aug Fri,Mon-Tue", outputString = "55 * * * 3,1,8 5,1-2"            , cronStringFormat = CronStringFormat.WithSeconds },
+                new { inputString = "* * * */2 *"                     , outputString = "* * * */2 *"                     , cronStringFormat = CronStringFormat.Default },
+                new { inputString = "10-40/15 * * * *"                , outputString = "10-40/15 * * * *"                , cronStringFormat = CronStringFormat.Default },
+                new { inputString = "* * * Mar,Jan,Aug Fri,Mon-Tue"   , outputString = "* * * 3,1,8 5,1-2"               , cronStringFormat = CronStringFormat.Default },
+                new { inputString = "1 * 1-2,3 * * *"                 , outputString = "1 * 1-2,3 * * *"                 , cronStringFormat = CronStringFormat.WithSeconds },
+                new { inputString = "22 * * * */2 *"                  , outputString = "22 * * * */2 *"                  , cronStringFormat = CronStringFormat.WithSeconds },
+                new { inputString = "33 10-40/15 * * * *"             , outputString = "33 10-40/15 * * * *"             , cronStringFormat = CronStringFormat.WithSeconds },
+                new { inputString = "55 * * * Mar,Jan,Aug Fri,Mon-Tue", outputString = "55 * * * 3,1,8 5,1-2"            , cronStringFormat = CronStringFormat.WithSeconds },
             };
 
             foreach (var test in tests)
@@ -153,273 +153,281 @@ namespace NCrontab.Advanced.Tests
         {
             var tests = new[]
             {
-                new { startTime = "01/01/2016 00:00:00", inputString = "* * ? * *", nextOccurence = "01/01/2016 00:01:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2016 00:01:00", inputString = "* * * * ?", nextOccurence = "01/01/2016 00:02:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2016 00:02:00", inputString = "* * ? * ?", nextOccurence = "01/01/2016 00:03:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2016 00:00:00", inputString = "* * ? * *", nextOccurence = "01/01/2016 00:01:00", previousOccurence = "31/12/2015 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2016 00:01:00", inputString = "* * * * ?", nextOccurence = "01/01/2016 00:02:00", previousOccurence = "01/01/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2016 00:02:00", inputString = "* * ? * ?", nextOccurence = "01/01/2016 00:03:00", previousOccurence = "01/01/2016 00:01:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "01/01/2003 00:00:00", inputString = "* * * * *", nextOccurence = "01/01/2003 00:01:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:01:00", inputString = "* * * * *", nextOccurence = "01/01/2003 00:02:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:02:00", inputString = "* * * * *", nextOccurence = "01/01/2003 00:03:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:58:00", inputString = "* * * * *", nextOccurence = "01/01/2003 00:59:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 01:58:00", inputString = "* * * * *", nextOccurence = "01/01/2003 01:59:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:59:00", inputString = "* * * * *", nextOccurence = "01/01/2003 01:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 01:59:00", inputString = "* * * * *", nextOccurence = "01/01/2003 02:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 23:59:00", inputString = "* * * * *", nextOccurence = "02/01/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "31/12/2003 23:59:00", inputString = "* * * * *", nextOccurence = "01/01/2004 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "28/02/2003 23:59:00", inputString = "* * * * *", nextOccurence = "01/03/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "28/02/2004 23:59:00", inputString = "* * * * *", nextOccurence = "29/02/2004 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:00:00", inputString = "* * * * *", nextOccurence = "01/01/2003 00:01:00", previousOccurence = "31/12/2002 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:01:00", inputString = "* * * * *", nextOccurence = "01/01/2003 00:02:00", previousOccurence = "01/01/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:02:00", inputString = "* * * * *", nextOccurence = "01/01/2003 00:03:00", previousOccurence = "01/01/2003 00:01:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:58:00", inputString = "* * * * *", nextOccurence = "01/01/2003 00:59:00", previousOccurence = "01/01/2003 00:57:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 01:58:00", inputString = "* * * * *", nextOccurence = "01/01/2003 01:59:00", previousOccurence = "01/01/2003 01:57:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:59:00", inputString = "* * * * *", nextOccurence = "01/01/2003 01:00:00", previousOccurence = "01/01/2003 00:58:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 01:59:00", inputString = "* * * * *", nextOccurence = "01/01/2003 02:00:00", previousOccurence = "01/01/2003 01:58:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 23:59:00", inputString = "* * * * *", nextOccurence = "02/01/2003 00:00:00", previousOccurence = "01/01/2003 23:58:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "31/12/2003 23:59:00", inputString = "* * * * *", nextOccurence = "01/01/2004 00:00:00", previousOccurence = "31/12/2003 23:58:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "28/02/2003 23:59:00", inputString = "* * * * *", nextOccurence = "01/03/2003 00:00:00", previousOccurence = "28/02/2003 23:58:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "28/02/2004 23:59:00", inputString = "* * * * *", nextOccurence = "29/02/2004 00:00:00", previousOccurence = "28/02/2004 23:58:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "01/01/2003 00:00:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:00:01", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:00:01", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:00:02", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:00:02", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:00:03", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:00:58", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:00:59", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:01:58", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:01:59", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:00:59", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:01:00", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:01:59", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:02:00", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 23:59:59", inputString = "* * * * * *", nextOccurence = "02/01/2003 00:00:00", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "31/12/2003 23:59:59", inputString = "* * * * * *", nextOccurence = "01/01/2004 00:00:00", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "28/02/2003 23:59:59", inputString = "* * * * * *", nextOccurence = "01/03/2003 00:00:00", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "28/02/2004 23:59:59", inputString = "* * * * * *", nextOccurence = "29/02/2004 00:00:00", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:00:01", previousOccurence = "31/12/2002 23:59:59", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:01", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:00:02", previousOccurence = "01/01/2003 00:00:00", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:02", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:00:03", previousOccurence = "01/01/2003 00:00:01", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:58", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:00:59", previousOccurence = "01/01/2003 00:00:57", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:01:58", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:01:59", previousOccurence = "01/01/2003 00:01:57", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:59", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:01:00", previousOccurence = "01/01/2003 00:00:58", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:01:59", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:02:00", previousOccurence = "01/01/2003 00:01:58", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 23:59:59", inputString = "* * * * * *", nextOccurence = "02/01/2003 00:00:00", previousOccurence = "01/01/2003 23:59:58", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "31/12/2003 23:59:59", inputString = "* * * * * *", nextOccurence = "01/01/2004 00:00:00", previousOccurence = "31/12/2003 23:59:58", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "28/02/2003 23:59:59", inputString = "* * * * * *", nextOccurence = "01/03/2003 00:00:00", previousOccurence = "28/02/2003 23:59:58", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "28/02/2004 23:59:59", inputString = "* * * * * *", nextOccurence = "29/02/2004 00:00:00", previousOccurence = "28/02/2004 23:59:58", cronStringFormat = CronStringFormat.WithSeconds },
 
-                new { startTime = "01/01/2003 00:00:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:01:00", cronStringFormat = CronStringFormat.WithYears },
-                new { startTime = "01/01/2003 00:01:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:02:00", cronStringFormat = CronStringFormat.WithYears },
-                new { startTime = "01/01/2003 00:02:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:03:00", cronStringFormat = CronStringFormat.WithYears },
-                new { startTime = "01/01/2003 00:58:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:59:00", cronStringFormat = CronStringFormat.WithYears },
-                new { startTime = "01/01/2003 01:58:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 01:59:00", cronStringFormat = CronStringFormat.WithYears },
-                new { startTime = "01/01/2003 00:59:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 01:00:00", cronStringFormat = CronStringFormat.WithYears },
-                new { startTime = "01/01/2003 01:59:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 02:00:00", cronStringFormat = CronStringFormat.WithYears },
-                new { startTime = "01/01/2003 23:59:00", inputString = "* * * * * *", nextOccurence = "02/01/2003 00:00:00", cronStringFormat = CronStringFormat.WithYears },
-                new { startTime = "31/12/2003 23:59:00", inputString = "* * * * * *", nextOccurence = "01/01/2004 00:00:00", cronStringFormat = CronStringFormat.WithYears },
-                new { startTime = "28/02/2003 23:59:00", inputString = "* * * * * *", nextOccurence = "01/03/2003 00:00:00", cronStringFormat = CronStringFormat.WithYears },
-                new { startTime = "28/02/2004 23:59:00", inputString = "* * * * * *", nextOccurence = "29/02/2004 00:00:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "01/01/2003 00:00:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:01:00", previousOccurence = "31/12/2002 23:59:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "01/01/2003 00:01:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:02:00", previousOccurence = "01/01/2003 00:00:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "01/01/2003 00:02:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:03:00", previousOccurence = "01/01/2003 00:01:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "01/01/2003 00:58:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 00:59:00", previousOccurence = "01/01/2003 00:57:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "01/01/2003 01:58:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 01:59:00", previousOccurence = "01/01/2003 01:57:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "01/01/2003 00:59:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 01:00:00", previousOccurence = "01/01/2003 00:58:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "01/01/2003 01:59:00", inputString = "* * * * * *", nextOccurence = "01/01/2003 02:00:00", previousOccurence = "01/01/2003 01:58:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "01/01/2003 23:59:00", inputString = "* * * * * *", nextOccurence = "02/01/2003 00:00:00", previousOccurence = "01/01/2003 23:58:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "31/12/2003 23:59:00", inputString = "* * * * * *", nextOccurence = "01/01/2004 00:00:00", previousOccurence = "31/12/2003 23:58:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "28/02/2003 23:59:00", inputString = "* * * * * *", nextOccurence = "01/03/2003 00:00:00", previousOccurence = "28/02/2003 23:58:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "28/02/2004 23:59:00", inputString = "* * * * * *", nextOccurence = "29/02/2004 00:00:00", previousOccurence = "28/02/2004 23:58:00", cronStringFormat = CronStringFormat.WithYears },
 
-                new { startTime = "01/01/2003 00:00:00", inputString = "* * * * * * *", nextOccurence = "01/01/2003 00:00:01", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 00:00:01", inputString = "* * * * * * *", nextOccurence = "01/01/2003 00:00:02", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 00:00:02", inputString = "* * * * * * *", nextOccurence = "01/01/2003 00:00:03", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 00:00:58", inputString = "* * * * * * *", nextOccurence = "01/01/2003 00:00:59", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 00:01:58", inputString = "* * * * * * *", nextOccurence = "01/01/2003 00:01:59", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 00:00:59", inputString = "* * * * * * *", nextOccurence = "01/01/2003 00:01:00", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 00:01:59", inputString = "* * * * * * *", nextOccurence = "01/01/2003 00:02:00", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 23:59:59", inputString = "* * * * * * *", nextOccurence = "02/01/2003 00:00:00", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "31/12/2003 23:59:59", inputString = "* * * * * * *", nextOccurence = "01/01/2004 00:00:00", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "28/02/2003 23:59:59", inputString = "* * * * * * *", nextOccurence = "01/03/2003 00:00:00", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "28/02/2004 23:59:59", inputString = "* * * * * * *", nextOccurence = "29/02/2004 00:00:00", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:00", inputString = "* * * * * * *", nextOccurence = "01/01/2003 00:00:01", previousOccurence = "31/12/2002 23:59:59", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:01", inputString = "* * * * * * *", nextOccurence = "01/01/2003 00:00:02", previousOccurence = "01/01/2003 00:00:00", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:02", inputString = "* * * * * * *", nextOccurence = "01/01/2003 00:00:03", previousOccurence = "01/01/2003 00:00:01", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:58", inputString = "* * * * * * *", nextOccurence = "01/01/2003 00:00:59", previousOccurence = "01/01/2003 00:00:57", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:01:58", inputString = "* * * * * * *", nextOccurence = "01/01/2003 00:01:59", previousOccurence = "01/01/2003 00:01:57", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:59", inputString = "* * * * * * *", nextOccurence = "01/01/2003 00:01:00", previousOccurence = "01/01/2003 00:00:58", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:01:59", inputString = "* * * * * * *", nextOccurence = "01/01/2003 00:02:00", previousOccurence = "01/01/2003 00:01:58", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 23:59:59", inputString = "* * * * * * *", nextOccurence = "02/01/2003 00:00:00", previousOccurence = "01/01/2003 23:59:58", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "31/12/2003 23:59:59", inputString = "* * * * * * *", nextOccurence = "01/01/2004 00:00:00", previousOccurence = "31/12/2003 23:59:58", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "28/02/2003 23:59:59", inputString = "* * * * * * *", nextOccurence = "01/03/2003 00:00:00", previousOccurence = "28/02/2003 23:59:58", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "28/02/2004 23:59:59", inputString = "* * * * * * *", nextOccurence = "29/02/2004 00:00:00", previousOccurence = "28/02/2004 23:59:58", cronStringFormat = CronStringFormat.WithSecondsAndYears },
 
 
-                // Second tests
+                //// Second tests
 
-                new { startTime = "01/01/2003 00:00:00", inputString = "45 * * * * *", nextOccurence = "01/01/2003 00:00:45", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:00:00", inputString = "45 * * * * ?", nextOccurence = "01/01/2003 00:00:45", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:00:00", inputString = "45 * * ? * *", nextOccurence = "01/01/2003 00:00:45", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:00", inputString = "45 * * * * *", nextOccurence = "01/01/2003 00:00:45", previousOccurence = "31/12/2002 23:59:45", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:00", inputString = "45 * * * * ?", nextOccurence = "01/01/2003 00:00:45", previousOccurence = "31/12/2002 23:59:45", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:00", inputString = "45 * * ? * *", nextOccurence = "01/01/2003 00:00:45", previousOccurence = "31/12/2002 23:59:45", cronStringFormat = CronStringFormat.WithSeconds },
 
-                new { startTime = "01/01/2003 00:00:00", inputString = "45-47,48,49 * * * * *", nextOccurence = "01/01/2003 00:00:45", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:00:45", inputString = "45-47,48,49 * * * * *", nextOccurence = "01/01/2003 00:00:46", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:00:46", inputString = "45-47,48,49 * * * * *", nextOccurence = "01/01/2003 00:00:47", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:00:47", inputString = "45-47,48,49 * * * * *", nextOccurence = "01/01/2003 00:00:48", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:00:48", inputString = "45-47,48,49 * * * * *", nextOccurence = "01/01/2003 00:00:49", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:00:49", inputString = "45-47,48,49 * * * * *", nextOccurence = "01/01/2003 00:01:45", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:00", inputString = "45-47,48,49 * * * * *", nextOccurence = "01/01/2003 00:00:45", previousOccurence = "31/12/2002 23:59:49", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:45", inputString = "45-47,48,49 * * * * *", nextOccurence = "01/01/2003 00:00:46", previousOccurence = "31/12/2002 23:59:49", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:46", inputString = "45-47,48,49 * * * * *", nextOccurence = "01/01/2003 00:00:47", previousOccurence = "01/01/2003 00:00:45", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:47", inputString = "45-47,48,49 * * * * *", nextOccurence = "01/01/2003 00:00:48", previousOccurence = "01/01/2003 00:00:46", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:48", inputString = "45-47,48,49 * * * * *", nextOccurence = "01/01/2003 00:00:49", previousOccurence = "01/01/2003 00:00:47", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:49", inputString = "45-47,48,49 * * * * *", nextOccurence = "01/01/2003 00:01:45", previousOccurence = "01/01/2003 00:00:48", cronStringFormat = CronStringFormat.WithSeconds },
 
-                new { startTime = "01/01/2003 00:00:00", inputString = "2/5 * * * * *", nextOccurence = "01/01/2003 00:00:02", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:00:02", inputString = "2/5 * * * * *", nextOccurence = "01/01/2003 00:00:07", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:00:50", inputString = "2/5 * * * * *", nextOccurence = "01/01/2003 00:00:52", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:00:52", inputString = "2/5 * * * * *", nextOccurence = "01/01/2003 00:00:57", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:00:57", inputString = "2/5 * * * * *", nextOccurence = "01/01/2003 00:01:02", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:00", inputString = "2/5 * * * * *", nextOccurence = "01/01/2003 00:00:02", previousOccurence = "31/12/2002 23:59:57", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:02", inputString = "2/5 * * * * *", nextOccurence = "01/01/2003 00:00:07", previousOccurence = "31/12/2002 23:59:57", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:50", inputString = "2/5 * * * * *", nextOccurence = "01/01/2003 00:00:52", previousOccurence = "01/01/2003 00:00:47", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:52", inputString = "2/5 * * * * *", nextOccurence = "01/01/2003 00:00:57", previousOccurence = "01/01/2003 00:00:47", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:57", inputString = "2/5 * * * * *", nextOccurence = "01/01/2003 00:01:02", previousOccurence = "01/01/2003 00:00:52", cronStringFormat = CronStringFormat.WithSeconds },
 
-                new { startTime = "01/01/2003 00:00:00", inputString = "45 * * * * * *", nextOccurence = "01/01/2003 00:00:45", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:00", inputString = "45 * * * * * *", nextOccurence = "01/01/2003 00:00:45", previousOccurence = "31/12/2002 23:59:45", cronStringFormat = CronStringFormat.WithSecondsAndYears },
 
-                new { startTime = "01/01/2003 00:00:00", inputString = "45-47,48,49 * * * * * *", nextOccurence = "01/01/2003 00:00:45", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 00:00:45", inputString = "45-47,48,49 * * * * * *", nextOccurence = "01/01/2003 00:00:46", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 00:00:46", inputString = "45-47,48,49 * * * * * *", nextOccurence = "01/01/2003 00:00:47", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 00:00:47", inputString = "45-47,48,49 * * * * * *", nextOccurence = "01/01/2003 00:00:48", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 00:00:48", inputString = "45-47,48,49 * * * * * *", nextOccurence = "01/01/2003 00:00:49", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 00:00:49", inputString = "45-47,48,49 * * * * * *", nextOccurence = "01/01/2003 00:01:45", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:00", inputString = "45-47,48,49 * * * * * *", nextOccurence = "01/01/2003 00:00:45", previousOccurence = "31/12/2002 23:59:49", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:45", inputString = "45-47,48,49 * * * * * *", nextOccurence = "01/01/2003 00:00:46", previousOccurence = "31/12/2002 23:59:49", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:46", inputString = "45-47,48,49 * * * * * *", nextOccurence = "01/01/2003 00:00:47", previousOccurence = "01/01/2003 00:00:45", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:47", inputString = "45-47,48,49 * * * * * *", nextOccurence = "01/01/2003 00:00:48", previousOccurence = "01/01/2003 00:00:46", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:48", inputString = "45-47,48,49 * * * * * *", nextOccurence = "01/01/2003 00:00:49", previousOccurence = "01/01/2003 00:00:47", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:49", inputString = "45-47,48,49 * * * * * *", nextOccurence = "01/01/2003 00:01:45", previousOccurence = "01/01/2003 00:00:48", cronStringFormat = CronStringFormat.WithSecondsAndYears },
 
-                new { startTime = "01/01/2003 00:00:00", inputString = "2/5 * * * * * *", nextOccurence = "01/01/2003 00:00:02", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 00:00:02", inputString = "2/5 * * * * * *", nextOccurence = "01/01/2003 00:00:07", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 00:00:50", inputString = "2/5 * * * * * *", nextOccurence = "01/01/2003 00:00:52", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 00:00:52", inputString = "2/5 * * * * * *", nextOccurence = "01/01/2003 00:00:57", cronStringFormat = CronStringFormat.WithSecondsAndYears },
-                new { startTime = "01/01/2003 00:00:57", inputString = "2/5 * * * * * *", nextOccurence = "01/01/2003 00:01:02", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:00", inputString = "2/5 * * * * * *", nextOccurence = "01/01/2003 00:00:02", previousOccurence = "31/12/2002 23:59:57", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:02", inputString = "2/5 * * * * * *", nextOccurence = "01/01/2003 00:00:07", previousOccurence = "31/12/2002 23:59:57", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:50", inputString = "2/5 * * * * * *", nextOccurence = "01/01/2003 00:00:52", previousOccurence = "01/01/2003 00:00:47", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:52", inputString = "2/5 * * * * * *", nextOccurence = "01/01/2003 00:00:57", previousOccurence = "01/01/2003 00:00:47", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                new { startTime = "01/01/2003 00:00:57", inputString = "2/5 * * * * * *", nextOccurence = "01/01/2003 00:01:02", previousOccurence = "01/01/2003 00:00:52", cronStringFormat = CronStringFormat.WithSecondsAndYears },
 
-                // Minute tests
+                //// Minute tests
 
-                new { startTime = "01/01/2003 00:00:00", inputString = "45 * * * *", nextOccurence = "01/01/2003 00:45:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:00:00", inputString = "45 * * * *", nextOccurence = "01/01/2003 00:45:00", previousOccurence = "31/12/2002 23:45:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "01/01/2003 00:00:00", inputString = "45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:45:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:45:00", inputString = "45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:46:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:46:00", inputString = "45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:47:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:47:00", inputString = "45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:48:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:48:00", inputString = "45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:49:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:49:00", inputString = "45-47,48,49 * * * *", nextOccurence = "01/01/2003 01:45:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:00:00", inputString = "45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:45:00", previousOccurence = "31/12/2002 23:49:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:45:00", inputString = "45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:46:00", previousOccurence = "31/12/2002 23:49:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:46:00", inputString = "45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:47:00", previousOccurence = "01/01/2003 00:45:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:47:00", inputString = "45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:48:00", previousOccurence = "01/01/2003 00:46:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:48:00", inputString = "45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:49:00", previousOccurence = "01/01/2003 00:47:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:49:00", inputString = "45-47,48,49 * * * *", nextOccurence = "01/01/2003 01:45:00", previousOccurence = "01/01/2003 00:48:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "01/01/2003 00:00:00", inputString = "2/5 * * * *", nextOccurence = "01/01/2003 00:02:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:02:00", inputString = "2/5 * * * *", nextOccurence = "01/01/2003 00:07:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:50:00", inputString = "2/5 * * * *", nextOccurence = "01/01/2003 00:52:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:52:00", inputString = "2/5 * * * *", nextOccurence = "01/01/2003 00:57:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:57:00", inputString = "2/5 * * * *", nextOccurence = "01/01/2003 01:02:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:00:00", inputString = "2/5 * * * *", nextOccurence = "01/01/2003 00:02:00", previousOccurence = "31/12/2002 23:57:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:02:00", inputString = "2/5 * * * *", nextOccurence = "01/01/2003 00:07:00", previousOccurence = "31/12/2002 23:57:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:50:00", inputString = "2/5 * * * *", nextOccurence = "01/01/2003 00:52:00", previousOccurence = "01/01/2003 00:47:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:52:00", inputString = "2/5 * * * *", nextOccurence = "01/01/2003 00:57:00", previousOccurence = "01/01/2003 00:47:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:57:00", inputString = "2/5 * * * *", nextOccurence = "01/01/2003 01:02:00", previousOccurence = "01/01/2003 00:52:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "01/01/2003 00:00:30", inputString = "3 45 * * * *", nextOccurence = "01/01/2003 00:45:03", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:30", inputString = "3 45 * * * *", nextOccurence = "01/01/2003 00:45:03", previousOccurence = "31/12/2002 23:45:03", cronStringFormat = CronStringFormat.WithSeconds },
 
-                new { startTime = "01/01/2003 00:00:30", inputString = "6 45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:45:06", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:45:30", inputString = "6 45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:46:06", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:46:30", inputString = "6 45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:47:06", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:47:30", inputString = "6 45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:48:06", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:48:30", inputString = "6 45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:49:06", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:49:30", inputString = "6 45-47,48,49 * * * *", nextOccurence = "01/01/2003 01:45:06", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:30", inputString = "6 45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:45:06", previousOccurence = "31/12/2002 23:49:06", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:45:30", inputString = "6 45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:46:06", previousOccurence = "01/01/2003 00:45:06", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:46:30", inputString = "6 45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:47:06", previousOccurence = "01/01/2003 00:46:06", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:47:30", inputString = "6 45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:48:06", previousOccurence = "01/01/2003 00:47:06", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:48:30", inputString = "6 45-47,48,49 * * * *", nextOccurence = "01/01/2003 00:49:06", previousOccurence = "01/01/2003 00:48:06", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:49:30", inputString = "6 45-47,48,49 * * * *", nextOccurence = "01/01/2003 01:45:06", previousOccurence = "01/01/2003 00:49:06", cronStringFormat = CronStringFormat.WithSeconds },
 
-                new { startTime = "01/01/2003 00:00:30", inputString = "9 2/5 * * * *", nextOccurence = "01/01/2003 00:02:09", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:02:30", inputString = "9 2/5 * * * *", nextOccurence = "01/01/2003 00:07:09", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:50:30", inputString = "9 2/5 * * * *", nextOccurence = "01/01/2003 00:52:09", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:52:30", inputString = "9 2/5 * * * *", nextOccurence = "01/01/2003 00:57:09", cronStringFormat = CronStringFormat.WithSeconds },
-                new { startTime = "01/01/2003 00:57:30", inputString = "9 2/5 * * * *", nextOccurence = "01/01/2003 01:02:09", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:00:30", inputString = "9 2/5 * * * *", nextOccurence = "01/01/2003 00:02:09", previousOccurence = "31/12/2002 23:57:09", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:02:30", inputString = "9 2/5 * * * *", nextOccurence = "01/01/2003 00:07:09", previousOccurence = "01/01/2003 00:02:09", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:50:30", inputString = "9 2/5 * * * *", nextOccurence = "01/01/2003 00:52:09", previousOccurence = "01/01/2003 00:47:09", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:52:30", inputString = "9 2/5 * * * *", nextOccurence = "01/01/2003 00:57:09", previousOccurence = "01/01/2003 00:52:09", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/01/2003 00:57:30", inputString = "9 2/5 * * * *", nextOccurence = "01/01/2003 01:02:09", previousOccurence = "01/01/2003 00:57:09", cronStringFormat = CronStringFormat.WithSeconds },
 
-                // Hour tests
+                //// Hour tests
 
-                new { startTime = "20/12/2003 10:00:00", inputString = " * 3/4 * * *", nextOccurence = "20/12/2003 11:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "20/12/2003 00:30:00", inputString = " * 3   * * *", nextOccurence = "20/12/2003 03:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "20/12/2003 01:45:00", inputString = "30 3   * * *", nextOccurence = "20/12/2003 03:30:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "20/12/2003 22:55:00", inputString = "*/15 9-23 * * *", nextOccurence = "20/12/2003 23:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "20/12/2003 10:00:00", inputString = " * 3/4 * * *", nextOccurence = "20/12/2003 11:00:00", previousOccurence = "20/12/2003 07:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "20/12/2003 00:30:00", inputString = " * 3   * * *", nextOccurence = "20/12/2003 03:00:00", previousOccurence = "19/12/2003 03:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "20/12/2003 01:45:00", inputString = "30 3   * * *", nextOccurence = "20/12/2003 03:30:00", previousOccurence = "19/12/2003 03:30:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "20/12/2003 22:55:00", inputString = "*/15 9-23 * * *", nextOccurence = "20/12/2003 23:00:00", previousOccurence = "20/12/2003 22:45:00", cronStringFormat = CronStringFormat.Default },
 
-                // Day of month tests
+                //// Day of month tests
 
-                new { startTime = "07/01/2003 00:00:00", inputString = "30  *  1 * *", nextOccurence = "01/02/2003 00:30:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/02/2003 00:30:00", inputString = "30  *  1 * *", nextOccurence = "01/02/2003 01:30:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "07/01/2003 00:00:00", inputString = "30  *  1 * *", nextOccurence = "01/02/2003 00:30:00", previousOccurence = "01/01/2003 23:30:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/02/2003 00:30:00", inputString = "30  *  1 * *", nextOccurence = "01/02/2003 01:30:00", previousOccurence = "01/01/2003 23:30:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "01/01/2003 00:00:00", inputString = "10  * 22    * *", nextOccurence = "22/01/2003 00:10:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:00:00", inputString = "30 23 19    * *", nextOccurence = "19/01/2003 23:30:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:00:00", inputString = "30 23 21    * *", nextOccurence = "21/01/2003 23:30:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:01:00", inputString = " *  * 21    * *", nextOccurence = "21/01/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "10/07/2003 00:00:00", inputString = " *  * 30,31 * *", nextOccurence = "30/07/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "20/01/2016 00:00:00", inputString = " *  * 1W * *", nextOccurence = "01/02/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "28/04/2016 00:00:00", inputString = " *  * 1W * *", nextOccurence = "02/05/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "30/09/2016 00:00:00", inputString = " *  * 1W * *", nextOccurence = "03/10/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/02/2003 00:00:00", inputString = " *  * 15W * *", nextOccurence = "14/02/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/06/2003 00:00:00", inputString = " *  * 15W * *", nextOccurence = "16/06/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "10/08/2003 00:00:00", inputString = " *  * LW * *", nextOccurence = "29/08/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "10/10/2015 00:00:00", inputString = " *  * LW * *", nextOccurence = "30/10/2015 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "10/07/2003 00:00:00", inputString = " *  * L * *", nextOccurence = "31/07/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/02/2015 00:00:00", inputString = " *  * L * *", nextOccurence = "28/02/2015 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/02/2016 00:00:00", inputString = " *  * L * *", nextOccurence = "29/02/2016 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:00:00", inputString = "10  * 22    * *", nextOccurence = "22/01/2003 00:10:00", previousOccurence="22/12/2002 23:10:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:00:00", inputString = "30 23 19    * *", nextOccurence = "19/01/2003 23:30:00", previousOccurence="19/12/2002 23:30:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:00:00", inputString = "30 23 21    * *", nextOccurence = "21/01/2003 23:30:00", previousOccurence="21/12/2002 23:30:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:01:00", inputString = " *  * 21    * *", nextOccurence = "21/01/2003 00:00:00", previousOccurence="21/12/2002 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "10/07/2003 00:00:00", inputString = " *  * 30,31 * *", nextOccurence = "30/07/2003 00:00:00", previousOccurence="30/06/2003 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "20/01/2016 00:00:00", inputString = " *  * 1W * *", nextOccurence = "01/02/2016 00:00:00", previousOccurence="01/01/2016 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "28/04/2016 00:00:00", inputString = " *  * 1W * *", nextOccurence = "02/05/2016 00:00:00", previousOccurence="01/04/2016 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "30/09/2016 00:00:00", inputString = " *  * 1W * *", nextOccurence = "03/10/2016 00:00:00", previousOccurence="01/09/2016 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/02/2003 00:00:00", inputString = " *  * 15W * *", nextOccurence = "14/02/2003 00:00:00", previousOccurence="15/01/2003 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/06/2003 00:00:00", inputString = " *  * 15W * *", nextOccurence = "16/06/2003 00:00:00", previousOccurence="15/05/2003 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "10/08/2003 00:00:00", inputString = " *  * LW * *", nextOccurence = "29/08/2003 00:00:00", previousOccurence="31/07/2003 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "10/10/2015 00:00:00", inputString = " *  * LW * *", nextOccurence = "30/10/2015 00:00:00", previousOccurence="30/09/2015 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "10/07/2003 00:00:00", inputString = " *  * L * *", nextOccurence = "31/07/2003 00:00:00", previousOccurence="30/06/2003 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/02/2015 00:00:00", inputString = " *  * L * *", nextOccurence = "28/02/2015 00:00:00", previousOccurence="31/01/2015 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/03/2015 00:00:00", inputString = " *  * L * *", nextOccurence = "31/03/2015 00:00:00", previousOccurence="28/02/2015 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/02/2016 00:00:00", inputString = " *  * L * *", nextOccurence = "29/02/2016 00:00:00", previousOccurence="31/01/2016 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/03/2016 00:00:00", inputString = " *  * L * *", nextOccurence = "31/03/2016 00:00:00", previousOccurence="29/02/2016 23:59:00", cronStringFormat = CronStringFormat.Default },
 
-                // Test month rollovers for months with 28,29,30 and 31 days
+                //// Test month rollovers for months with 28,29,30 and 31 days
 
-                new { startTime = "28/02/2002 23:59:59", inputString = "* * * 3 *", nextOccurence = "01/03/2002 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "29/02/2004 23:59:59", inputString = "* * * 3 *", nextOccurence = "01/03/2004 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "31/03/2002 23:59:59", inputString = "* * * 4 *", nextOccurence = "01/04/2002 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "30/04/2002 23:59:59", inputString = "* * * 5 *", nextOccurence = "01/05/2002 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "28/02/2002 23:59:59", inputString = "* * * 3 *", nextOccurence = "01/03/2002 00:00:00", previousOccurence="31/03/2001 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "29/02/2004 23:59:59", inputString = "* * * 3 *", nextOccurence = "01/03/2004 00:00:00", previousOccurence="31/03/2003 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "31/03/2002 23:59:59", inputString = "* * * 4 *", nextOccurence = "01/04/2002 00:00:00", previousOccurence="30/04/2001 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "30/04/2002 23:59:59", inputString = "* * * 5 *", nextOccurence = "01/05/2002 00:00:00", previousOccurence="31/05/2001 23:59:00", cronStringFormat = CronStringFormat.Default },
 
-                // Test month 30,31 days
+                //// Test month 30,31 days
 
-                new { startTime = "01/01/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/01/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "15/01/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/01/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "30/01/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "31/01/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "31/01/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/02/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/01/2000 00:00:00", previousOccurence="31/12/1999 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "15/01/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/01/2000 00:00:00", previousOccurence="31/12/1999 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "30/01/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "31/01/2000 00:00:00", previousOccurence="15/01/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "31/01/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/02/2000 00:00:00", previousOccurence="30/01/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "15/02/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/03/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "15/02/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/03/2000 00:00:00", previousOccurence="31/01/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "15/03/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/03/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "30/03/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "31/03/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "31/03/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/04/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "15/03/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/03/2000 00:00:00", previousOccurence="15/02/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "30/03/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "31/03/2000 00:00:00", previousOccurence="15/03/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "31/03/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/04/2000 00:00:00", previousOccurence="30/03/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "15/04/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/04/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "30/04/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/05/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "15/04/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/04/2000 00:00:00", previousOccurence="31/03/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "30/04/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/05/2000 00:00:00", previousOccurence="15/04/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "15/05/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/05/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "30/05/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "31/05/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "31/05/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/06/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "15/05/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/05/2000 00:00:00", previousOccurence="30/04/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "30/05/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "31/05/2000 00:00:00", previousOccurence="15/05/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "31/05/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/06/2000 00:00:00", previousOccurence="30/05/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "15/06/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/06/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "30/06/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/07/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "15/06/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/06/2000 00:00:00", previousOccurence="31/05/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "30/06/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/07/2000 00:00:00", previousOccurence="15/06/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "15/07/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/07/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "30/07/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "31/07/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "31/07/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/08/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "15/07/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/07/2000 00:00:00", previousOccurence="30/06/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "30/07/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "31/07/2000 00:00:00", previousOccurence="15/07/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "31/07/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/08/2000 00:00:00", previousOccurence="30/07/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "15/08/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/08/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "30/08/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "31/08/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "31/08/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/09/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "15/08/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/08/2000 00:00:00", previousOccurence="31/07/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "30/08/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "31/08/2000 00:00:00", previousOccurence="15/08/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "31/08/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/09/2000 00:00:00", previousOccurence="30/08/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "15/09/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/09/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "30/09/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/10/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "15/09/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/09/2000 00:00:00", previousOccurence="31/08/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "30/09/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/10/2000 00:00:00", previousOccurence="15/09/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "15/10/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/10/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "30/10/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "31/10/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "31/10/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/11/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "15/10/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/10/2000 00:00:00", previousOccurence="30/09/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "30/10/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "31/10/2000 00:00:00", previousOccurence="15/10/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "31/10/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/11/2000 00:00:00", previousOccurence="30/10/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "15/11/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/11/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "30/11/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/12/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "15/11/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/11/2000 00:00:00", previousOccurence="31/10/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "30/11/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/12/2000 00:00:00", previousOccurence="15/11/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "15/12/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/12/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "30/12/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "31/12/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "31/12/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/01/2001 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "15/12/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/12/2000 00:00:00", previousOccurence="30/11/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "30/12/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "31/12/2000 00:00:00", previousOccurence="15/12/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "31/12/2000 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "15/01/2001 00:00:00", previousOccurence="30/12/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "15/01/2001 00:00:00", inputString = "0 0 15,30,31 * *", nextOccurence = "30/01/2001 00:00:00", previousOccurence="31/12/2000 00:00:00", cronStringFormat = CronStringFormat.Default },
 
-                // Other month tests (including year rollover)
+                //// Other month tests (including year rollover)
 
-                new { startTime = "01/12/2003 05:00:00", inputString = "10 * * 6 *", nextOccurence = "01/06/2004 00:10:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "04/01/2003 00:00:00", inputString = " 1 2 3 * *", nextOccurence = "03/02/2003 02:01:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/07/2002 05:00:00", inputString = "10 * * February,April-Jun *", nextOccurence = "01/02/2003 00:10:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 00:00:00", inputString = "0 12 1 6 *", nextOccurence = "01/06/2003 12:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "11/09/1988 14:23:00", inputString = "* 12 1 6 *", nextOccurence = "01/06/1989 12:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "11/03/1988 14:23:00", inputString = "* 12 1 6 *", nextOccurence = "01/06/1988 12:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "11/03/1988 14:23:00", inputString = "* 2,4-8,15 * 6 *", nextOccurence = "01/06/1988 02:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "11/03/1988 14:23:00", inputString = "20 * * january,FeB,Mar,april,May,JuNE,July,Augu,SEPT-October,Nov,DECEM *", nextOccurence = "11/03/1988 15:20:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "11/09/1988 14:23:00", inputString = "* 12 1 6 * 1988,1989", nextOccurence = "01/06/1989 12:00:00", cronStringFormat = CronStringFormat.WithYears },
-                new { startTime = "11/09/1988 14:23:00", inputString = "* 12 1 6 * 1988,2000", nextOccurence = "01/06/2000 12:00:00", cronStringFormat = CronStringFormat.WithYears },
-                new { startTime = "11/09/1988 14:23:00", inputString = "* 12 1 6 * 1988/5", nextOccurence = "01/06/1993 12:00:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "01/12/2003 05:00:00", inputString = "10 * * 6 *", nextOccurence = "01/06/2004 00:10:00", previousOccurence="30/06/2003 23:10:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "04/01/2003 00:00:00", inputString = " 1 2 3 * *", nextOccurence = "03/02/2003 02:01:00", previousOccurence="03/01/2003 02:01:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/07/2002 05:00:00", inputString = "10 * * February,April-Jun *", nextOccurence = "01/02/2003 00:10:00", previousOccurence="30/06/2002 23:10:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:00:00", inputString = "0 12 1 6 *", nextOccurence = "01/06/2003 12:00:00", previousOccurence="01/06/2002 12:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "11/09/1988 14:23:00", inputString = "* 12 1 6 *", nextOccurence = "01/06/1989 12:00:00", previousOccurence="01/06/1988 12:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "11/03/1988 14:23:00", inputString = "* 12 1 6 *", nextOccurence = "01/06/1988 12:00:00", previousOccurence="01/06/1987 12:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "11/03/1988 14:23:00", inputString = "* 2,4-8,15 * 6 *", nextOccurence = "01/06/1988 02:00:00", previousOccurence="30/06/1987 15:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "11/03/1988 14:23:00", inputString = "20 * * january,FeB,Mar,april,May,JuNE,July,Augu,SEPT-October,Nov,DECEM *", nextOccurence = "11/03/1988 15:20:00", previousOccurence="11/03/1988 14:20:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "11/09/1988 14:23:00", inputString = "* 12 1 6 * 1988,1989", nextOccurence = "01/06/1989 12:00:00", previousOccurence="01/06/1988 12:59:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "11/09/1988 14:23:00", inputString = "* 12 1 6 * 1988,2000", nextOccurence = "01/06/2000 12:00:00", previousOccurence="01/06/1988 12:59:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "11/09/1988 14:23:00", inputString = "* 12 1 6 * 1988/5", nextOccurence = "01/06/1993 12:00:00", previousOccurence="01/06/1988 12:59:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "11/05/1988 14:23:00", inputString = "* 12 1 6 * 1988/5", nextOccurence = "01/06/1988 12:00:00", previousOccurence="01/06/1983 12:59:00", cronStringFormat = CronStringFormat.WithYears },
 
-                // Day of week tests
+                // Returns DateTime.Min for previousOccurence as there is not date that matches before startTime
+                new { startTime = "11/03/1988 14:23:00", inputString = "* 12 1 6 * 1988,1989", nextOccurence = "01/06/1988 12:00:00", previousOccurence="01/01/0001 00:00:00", cronStringFormat = CronStringFormat.WithYears },
 
-                new { startTime = "26/06/2003 10:00:00", inputString = "30 6 * * 0", nextOccurence = "29/06/2003 06:30:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "26/06/2003 10:00:00", inputString = "30 6 * * sunday", nextOccurence = "29/06/2003 06:30:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "26/06/2003 10:00:00", inputString = "30 6 * * SUNDAY", nextOccurence = "29/06/2003 06:30:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "19/06/2003 00:00:00", inputString = "1 12 * * 2", nextOccurence = "24/06/2003 12:01:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "24/06/2003 12:01:00", inputString = "1 12 * * 2", nextOccurence = "01/07/2003 12:01:00", cronStringFormat = CronStringFormat.Default },
+                //// Day of week tests
 
-                new { startTime = "01/06/2003 14:55:00", inputString = "15 18 * * Mon", nextOccurence = "02/06/2003 18:15:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "02/06/2003 18:15:00", inputString = "15 18 * * Mon", nextOccurence = "09/06/2003 18:15:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "09/06/2003 18:15:00", inputString = "15 18 * * Mon", nextOccurence = "16/06/2003 18:15:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "16/06/2003 18:15:00", inputString = "15 18 * * Mon", nextOccurence = "23/06/2003 18:15:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "23/06/2003 18:15:00", inputString = "15 18 * * Mon", nextOccurence = "30/06/2003 18:15:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "30/06/2003 18:15:00", inputString = "15 18 * * Mon", nextOccurence = "07/07/2003 18:15:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "26/06/2003 10:00:00", inputString = "30 6 * * 0", nextOccurence = "29/06/2003 06:30:00", previousOccurence="22/06/2003 06:30:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "26/06/2003 10:00:00", inputString = "30 6 * * sunday", nextOccurence = "29/06/2003 06:30:00", previousOccurence="22/06/2003 06:30:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "26/06/2003 10:00:00", inputString = "30 6 * * SUNDAY", nextOccurence = "29/06/2003 06:30:00", previousOccurence="22/06/2003 06:30:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "19/06/2003 00:00:00", inputString = "1 12 * * 2", nextOccurence = "24/06/2003 12:01:00", previousOccurence="17/06/2003 12:01:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "24/06/2003 12:01:00", inputString = "1 12 * * 2", nextOccurence = "01/07/2003 12:01:00", previousOccurence="17/06/2003 12:01:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/07/2003 12:01:00", inputString = "1 12 * * 2", nextOccurence = "08/07/2003 12:01:00", previousOccurence="24/06/2003 12:01:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "01/01/2003 00:00:00", inputString = "* * * * Mon", nextOccurence = "06/01/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 12:00:00", inputString = "45 16 1 * Mon", nextOccurence = "01/09/2003 16:45:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/09/2003 23:45:00", inputString = "45 16 1 * Mon", nextOccurence = "01/12/2003 16:45:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/06/2003 14:55:00", inputString = "15 18 * * Mon", nextOccurence = "02/06/2003 18:15:00", previousOccurence="26/05/2003 18:15:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "02/06/2003 18:15:00", inputString = "15 18 * * Mon", nextOccurence = "09/06/2003 18:15:00", previousOccurence="26/05/2003 18:15:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "09/06/2003 18:15:00", inputString = "15 18 * * Mon", nextOccurence = "16/06/2003 18:15:00", previousOccurence="02/06/2003 18:15:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "16/06/2003 18:15:00", inputString = "15 18 * * Mon", nextOccurence = "23/06/2003 18:15:00", previousOccurence="09/06/2003 18:15:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "23/06/2003 18:15:00", inputString = "15 18 * * Mon", nextOccurence = "30/06/2003 18:15:00", previousOccurence="16/06/2003 18:15:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "30/06/2003 18:15:00", inputString = "15 18 * * Mon", nextOccurence = "07/07/2003 18:15:00", previousOccurence="23/06/2003 18:15:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "01/09/2003 23:45:00", inputString = "45 16 * * Mon#2", nextOccurence = "08/09/2003 16:45:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/09/2003 23:45:00", inputString = "45 16 * * 2#4", nextOccurence = "23/09/2003 16:45:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 00:00:00", inputString = "* * * * Mon", nextOccurence = "06/01/2003 00:00:00", previousOccurence="30/12/2002 23:59:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 12:00:00", inputString = "45 16 1 * Mon", nextOccurence = "01/09/2003 16:45:00", previousOccurence="01/07/2002 16:45:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/09/2003 23:45:00", inputString = "45 16 1 * Mon", nextOccurence = "01/12/2003 16:45:00", previousOccurence="01/09/2003 16:45:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * 0L", nextOccurence = "26/01/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * SUNL", nextOccurence = "26/01/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * SUNDL", nextOccurence = "26/01/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * SUNDAYL", nextOccurence = "26/01/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * 6L", nextOccurence = "25/01/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * SATL", nextOccurence = "25/01/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * SATUL", nextOccurence = "25/01/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * SATURDAYL", nextOccurence = "25/01/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/09/2003 23:45:00", inputString = "45 16 * * Mon#2", nextOccurence = "08/09/2003 16:45:00", previousOccurence="11/08/2003 16:45:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/09/2003 23:45:00", inputString = "45 16 * * 2#4", nextOccurence = "23/09/2003 16:45:00", previousOccurence="26/08/2003 16:45:00", cronStringFormat = CronStringFormat.Default },
 
-                // Leap year tests
+                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * 0L", nextOccurence = "26/01/2003 00:00:00", previousOccurence="29/12/2002 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * SUNL", nextOccurence = "26/01/2003 00:00:00", previousOccurence="29/12/2002 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * SUNDL", nextOccurence = "26/01/2003 00:00:00", previousOccurence="29/12/2002 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * SUNDAYL", nextOccurence = "26/01/2003 00:00:00", previousOccurence="29/12/2002 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * 6L", nextOccurence = "25/01/2003 00:00:00", previousOccurence="28/12/2002 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * SATL", nextOccurence = "25/01/2003 00:00:00", previousOccurence="28/12/2002 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * SATUL", nextOccurence = "25/01/2003 00:00:00", previousOccurence="28/12/2002 00:00:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "01/01/2003 23:45:00", inputString = "0 0 * * SATURDAYL", nextOccurence = "25/01/2003 00:00:00", previousOccurence="28/12/2002 00:00:00", cronStringFormat = CronStringFormat.Default },
 
-                new { startTime = "01/01/2000 12:00:00", inputString = "1 12 29 2 *", nextOccurence = "29/02/2000 12:01:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "29/02/2000 12:01:00", inputString = "1 12 29 2 *", nextOccurence = "29/02/2004 12:01:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "29/02/2004 12:01:00", inputString = "1 12 29 2 *", nextOccurence = "29/02/2008 12:01:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "29/02/2004 12:01:00", inputString = "1 12 29 2 * */3", nextOccurence = "29/02/2016 12:01:00", cronStringFormat = CronStringFormat.WithYears },
-                new { startTime = "29/02/2004 12:01:00", inputString = "1 12 29 2 * 2005/3", nextOccurence = "29/02/2008 12:01:00", cronStringFormat = CronStringFormat.WithYears },
-                new { startTime = "29/02/2004 12:01:00", inputString = "1 12 29 2 * 2002/7", nextOccurence = "29/02/2016 12:01:00", cronStringFormat = CronStringFormat.WithYears },
+                //// Leap year tests
 
-                // Non-leap year tests
+                new { startTime = "01/01/2000 12:00:00", inputString = "1 12 29 2 *", nextOccurence = "29/02/2000 12:01:00", previousOccurence="29/02/1996 12:01:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "29/02/2000 12:01:00", inputString = "1 12 29 2 *", nextOccurence = "29/02/2004 12:01:00", previousOccurence="29/02/1996 12:01:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "29/02/2004 12:01:00", inputString = "1 12 29 2 *", nextOccurence = "29/02/2008 12:01:00", previousOccurence="29/02/2000 12:01:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "29/02/2004 12:01:00", inputString = "1 12 29 2 * */3", nextOccurence = "29/02/2016 12:01:00", previousOccurence="29/02/1992 12:01:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "29/02/2004 12:01:00", inputString = "1 12 29 2 * 2005/3", nextOccurence = "29/02/2008 12:01:00", previousOccurence="29/02/1996 12:01:00", cronStringFormat = CronStringFormat.WithYears },
+                new { startTime = "29/02/2004 12:01:00", inputString = "1 12 29 2 * 2002/7", nextOccurence = "29/02/2016 12:01:00", previousOccurence="29/02/1988 12:01:00", cronStringFormat = CronStringFormat.WithYears },
 
-                new { startTime = "01/01/2000 12:00:00", inputString = "1 12 28 2 *", nextOccurence = "28/02/2000 12:01:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "28/02/2000 12:01:00", inputString = "1 12 28 2 *", nextOccurence = "28/02/2001 12:01:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "28/02/2001 12:01:00", inputString = "1 12 28 2 *", nextOccurence = "28/02/2002 12:01:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "28/02/2002 12:01:00", inputString = "1 12 28 2 *", nextOccurence = "28/02/2003 12:01:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "28/02/2003 12:01:00", inputString = "1 12 28 2 *", nextOccurence = "28/02/2004 12:01:00", cronStringFormat = CronStringFormat.Default },
-                new { startTime = "29/02/2004 12:01:00", inputString = "1 12 28 2 *", nextOccurence = "28/02/2005 12:01:00", cronStringFormat = CronStringFormat.Default },
+                //// Non-leap year tests
+
+                new { startTime = "01/01/2000 12:00:00", inputString = "1 12 28 2 *", nextOccurence = "28/02/2000 12:01:00", previousOccurence="28/02/1999 12:01:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "28/02/2000 12:01:00", inputString = "1 12 28 2 *", nextOccurence = "28/02/2001 12:01:00", previousOccurence="28/02/1999 12:01:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "28/02/2001 12:01:00", inputString = "1 12 28 2 *", nextOccurence = "28/02/2002 12:01:00", previousOccurence="28/02/2000 12:01:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "28/02/2002 12:01:00", inputString = "1 12 28 2 *", nextOccurence = "28/02/2003 12:01:00", previousOccurence="28/02/2001 12:01:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "28/02/2003 12:01:00", inputString = "1 12 28 2 *", nextOccurence = "28/02/2004 12:01:00", previousOccurence="28/02/2002 12:01:00", cronStringFormat = CronStringFormat.Default },
+                new { startTime = "29/02/2004 12:01:00", inputString = "1 12 28 2 *", nextOccurence = "28/02/2005 12:01:00", previousOccurence="28/02/2004 12:01:00", cronStringFormat = CronStringFormat.Default },
 
                 // ? filter  tests
             };
 
             foreach (var test in tests)
-                CronCall(test.startTime, test.inputString, test.nextOccurence, test.cronStringFormat);
+                CronCall(test.startTime, test.inputString, test.nextOccurence, test.previousOccurence, test.cronStringFormat);
         }
 
         [TestMethod]
@@ -427,44 +435,44 @@ namespace NCrontab.Advanced.Tests
         {
             var tests = new[] {
                 // Fire at 12pm (noon) every day
-                 new { startTime = "22/05/1983 00:00:00", inputString = "0 0 12 * * ?"   , nextOccurence = "22/05/1983 12:00:00", cronStringFormat = CronStringFormat.WithSeconds },
+                 new { startTime = "22/05/1983 00:00:00", inputString = "0 0 12 * * ?"   , nextOccurence = "22/05/1983 12:00:00", previousOccurence="21/05/1983 12:00:00", cronStringFormat = CronStringFormat.WithSeconds },
                  
                  // Fire at 10:15am every day
-                 new { startTime = "22/05/1983 00:00:00", inputString = "0 15 10 ? * *"  , nextOccurence = "22/05/1983 10:15:00", cronStringFormat = CronStringFormat.WithSeconds },
-                 new { startTime = "22/05/1983 00:00:00", inputString = "0 15 10 * * ?"  , nextOccurence = "22/05/1983 10:15:00", cronStringFormat = CronStringFormat.WithSeconds },
-                 new { startTime = "22/05/1983 00:00:00", inputString = "0 15 10 * * ? *", nextOccurence = "22/05/1983 10:15:00", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                 new { startTime = "22/05/1983 00:00:00", inputString = "0 15 10 ? * *"  , nextOccurence = "22/05/1983 10:15:00", previousOccurence="21/05/1983 10:15:00", cronStringFormat = CronStringFormat.WithSeconds },
+                 new { startTime = "22/05/1983 00:00:00", inputString = "0 15 10 * * ?"  , nextOccurence = "22/05/1983 10:15:00", previousOccurence="21/05/1983 10:15:00", cronStringFormat = CronStringFormat.WithSeconds },
+                 new { startTime = "22/05/1983 00:00:00", inputString = "0 15 10 * * ? *", nextOccurence = "22/05/1983 10:15:00", previousOccurence="21/05/1983 10:15:00", cronStringFormat = CronStringFormat.WithSecondsAndYears },
                  
                  //Fire at 2:10pm and at 2:44pm every Wednesday in the month of March.
-                 new { startTime = "22/05/1983 00:00:00", inputString = "0 10,44 14 ? 3 WED", nextOccurence = "07/03/1984 14:10:00", cronStringFormat = CronStringFormat.WithSeconds },
+                 new { startTime = "22/05/1983 00:00:00", inputString = "0 10,44 14 ? 3 WED", nextOccurence = "07/03/1984 14:10:00", previousOccurence="30/03/1983 14:44:00", cronStringFormat = CronStringFormat.WithSeconds },
                  
                  // Fire at 10:15 AM on the last day of every month
-                 new { startTime = "22/05/1983 00:00:00", inputString = "0 15 10 L * ?", nextOccurence = "31/05/1983 10:15:00", cronStringFormat = CronStringFormat.WithSeconds },
+                 new { startTime = "22/05/1983 00:00:00", inputString = "0 15 10 L * ?", nextOccurence = "31/05/1983 10:15:00", previousOccurence="30/04/1983 10:15:00", cronStringFormat = CronStringFormat.WithSeconds },
                  
-                 // Fire at 10:15 AM on the last Friday of every month
-                 new { startTime = "01/07/1984 00:00:00", inputString = "0 15 10 ? * 6L", nextOccurence = "28/07/1984 10:15:00", cronStringFormat = CronStringFormat.WithSeconds },
+                 // Fire at 10:15 AM on the last Saturday of every month
+                 new { startTime = "01/07/1984 00:00:00", inputString = "0 15 10 ? * 6L", nextOccurence = "28/07/1984 10:15:00", previousOccurence="30/06/1984 10:15:00", cronStringFormat = CronStringFormat.WithSeconds },
                                    	
-                //Fire at ... AM on every last friday of every month during the years 2002, 2003, 2004, and 2005
-                new { startTime = "01/07/1984 00:00:00", inputString = "39 26 13 ? * 5L 2002-2005", nextOccurence = "25/01/2002 13:26:39", cronStringFormat = CronStringFormat.WithSecondsAndYears },
+                //Fire at 01:26:39 PM on every last friday of every month during the years 2002, 2003, 2004, and 2005
+                new { startTime = "01/07/2002 00:00:00", inputString = "39 26 13 ? * 5L 2002-2005", nextOccurence = "26/07/2002 13:26:39", previousOccurence="28/06/2002 13:26:39", cronStringFormat = CronStringFormat.WithSecondsAndYears },
 
-                //Fire at .. AM on the third SATURDAY of every month
-                new { startTime = "01/06/2016 00:00:00", inputString = "1 16 11 ? * 6#3", nextOccurence = "18/06/2016 11:16:01", cronStringFormat = CronStringFormat.WithSeconds },
+                //Fire at 11:16:01 AM on the third SATURDAY of every month
+                new { startTime = "01/06/2016 00:00:00", inputString = "1 16 11 ? * 6#3", nextOccurence = "18/06/2016 11:16:01", previousOccurence="21/05/2016 11:16:01", cronStringFormat = CronStringFormat.WithSeconds },
 
              	//Fire at 12 PM (noon) every 5 days every month, starting on the first day of the month
-                new { startTime = "01/07/1984 00:00:00", inputString = "1 2 12 1/5 * ?", nextOccurence = "01/07/1984 12:02:01", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/07/1984 00:00:00", inputString = "1 2 12 1/5 * ?", nextOccurence = "01/07/1984 12:02:01", previousOccurence="26/06/1984 12:02:01", cronStringFormat = CronStringFormat.WithSeconds },
 
                 //Fire every November 11 at 11:11 AM
-                new { startTime = "01/07/1984 00:00:00", inputString = "0 11 11 11 11 ?", nextOccurence = "11/11/1984 11:11:00", cronStringFormat = CronStringFormat.WithSeconds },
+                new { startTime = "01/07/1984 00:00:00", inputString = "0 11 11 11 11 ?", nextOccurence = "11/11/1984 11:11:00", previousOccurence="11/11/1983 11:11:00", cronStringFormat = CronStringFormat.WithSeconds },
             };
-                
+
             foreach (var test in tests)
-                CronCall(test.startTime, test.inputString, test.nextOccurence, test.cronStringFormat);
+                CronCall(test.startTime, test.inputString, test.nextOccurence, test.previousOccurence, test.cronStringFormat);
         }
 
 
         [TestMethod]
         public void FiniteOccurrences()
         {
-            var tests = new []
+            var tests = new[]
             {
                 new { inputString = " *  * * * *  ", startTime = "01/01/2003 00:00:00", endTime = "01/01/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
                 new { inputString = " *  * * * *  ", startTime = "31/12/2002 23:59:59", endTime = "01/01/2003 00:00:00", cronStringFormat = CronStringFormat.Default },
@@ -644,13 +652,17 @@ namespace NCrontab.Advanced.Tests
             Assert.IsFalse(stopWatch.ElapsedMilliseconds > 250, string.Format("Elapsed time should not exceed 250ms (was {0} ms)", stopWatch.ElapsedMilliseconds));
         }
 
-        static void CronCall(string startTimeString, string cronExpression, string nextTimeString, CronStringFormat format)
+        static void CronCall(string startTimeString, string cronExpression, string nextTimeString, string previousTimeString, CronStringFormat format)
         {
             var schedule = CrontabSchedule.Parse(cronExpression, format);
             var next = schedule.GetNextOccurrence(Time(startTimeString));
+            var previous = schedule.GetPreviousOccurrence(Time(startTimeString));
 
             var message = string.Format("Occurrence of <{0}> after <{1}>, format <{2}>.", cronExpression, startTimeString, Enum.GetName(typeof(CronStringFormat), format));
             Assert.AreEqual(nextTimeString, TimeString(next), message);
+
+            var previousMessage = string.Format("Occurrence of <{0}> before <{1}>, format <{2}>.", cronExpression, startTimeString, Enum.GetName(typeof(CronStringFormat), format));
+            Assert.AreEqual(previousTimeString, TimeString(previous), previousMessage);
         }
 
         static void CronFinite(string cronExpression, string startTimeString, string endTimeString, CronStringFormat format)

--- a/NCrontab.Advanced.Tests/CronInstanceTests.cs
+++ b/NCrontab.Advanced.Tests/CronInstanceTests.cs
@@ -608,6 +608,18 @@ namespace NCrontab.Advanced.Tests
             BadField("* * 3-l2 * * *", CronStringFormat.WithSeconds);
         }
 
+
+        [TestMethod]
+        public void DaysOfTheWeek()
+        {
+            var parser = CrontabSchedule.Parse("* * * * Mon,Tue,Wed,Thu,Fri,Sat,Sun");
+            Assert.AreEqual(7, parser.Filters[CrontabFieldKind.DayOfWeek].Count);
+        }
+
+        [TestMethod]
+        public void DaysOfTheWeekInTurkishCulture()
+         => TestHelpers.ExecuteWithCulture("tr-TR", DaysOfTheWeek);
+
         [TestMethod]
         public void MultipleInstancesTest()
         {

--- a/NCrontab.Advanced.Tests/NCrontab.Advanced.Tests.csproj
+++ b/NCrontab.Advanced.Tests/NCrontab.Advanced.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Extensions\AssertExtensions.cs" />
     <Compile Include="FilterTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NCrontab.Advanced\NCrontab.Advanced.csproj">

--- a/NCrontab.Advanced.Tests/TestHelpers.cs
+++ b/NCrontab.Advanced.Tests/TestHelpers.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+
+namespace NCrontab.Advanced.Tests
+{
+    public static class TestHelpers
+    {
+        // https://stackoverflow.com/questions/32382843/how-can-i-set-the-culture-for-individual-mstest-test-methods
+        public static void ExecuteWithCulture(string cultureName, Action action)
+        {
+            Exception exception = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception e)
+                {
+                    exception = e;
+                }
+            });
+
+            thread.CurrentCulture = new CultureInfo(cultureName);
+            thread.Start();
+            thread.Join();
+
+            if (exception != null)
+                throw new Exception("Exception occured running in the culture " + cultureName, exception);
+        }
+    }
+}

--- a/NCrontab.Advanced/CrontabSchedule.cs
+++ b/NCrontab.Advanced/CrontabSchedule.cs
@@ -282,7 +282,7 @@ namespace NCrontab.Advanced
 
         private static ICronFilter ParseFilter(string filter, CrontabFieldKind kind)
         {
-            var newFilter = filter.ToUpper();
+            var newFilter = filter.ToUpperInvariant();
 
             try
             {

--- a/NCrontab.Advanced/CrontabSchedule.cs
+++ b/NCrontab.Advanced/CrontabSchedule.cs
@@ -281,7 +281,7 @@ namespace NCrontab.Advanced
 
                 // In instances where the year is filtered, this will speed up the path to get to endValue
                 // (without having to actually go to endValue)
-                if (isYearFormat && yearFilters.Select(x => x.Next(newValue.Year - 1)).All(x => x == null)) return endValue;
+                if (isYearFormat && yearFilters.Select(x => x.Previous(newValue.Year + 1)).All(x => x == null)) return endValue;
 
                 // Ugh...have to do the try/catch again...
                 try { newValue = newValue.AddDays(-1); } catch { return endValue; }

--- a/NCrontab.Advanced/CrontabSchedule.cs
+++ b/NCrontab.Advanced/CrontabSchedule.cs
@@ -45,10 +45,21 @@ namespace NCrontab.Advanced
             return GetNextOccurrence(baseValue, DateTime.MaxValue);
         }
 
+        public DateTime GetPreviousOccurrence(DateTime baseValue)
+        {
+            return GetPreviousOccurrence(baseValue, DateTime.MinValue);
+        }
+
         public DateTime GetNextOccurrence(DateTime baseValue, DateTime endValue)
         {
             return InternalGetNextOccurence(baseValue, endValue);
         }
+
+        public DateTime GetPreviousOccurrence(DateTime baseValue, DateTime endValue)
+        {
+            return InternalGetPreviousOccurence(baseValue, endValue);
+        }
+
         public IEnumerable<DateTime> GetNextOccurrences(DateTime baseTime, DateTime endTime)
         {
             for (var occurrence = GetNextOccurrence(baseTime, endTime);
@@ -67,9 +78,21 @@ namespace NCrontab.Advanced
             return nextValue;
         }
 
+        private int Decrement(IEnumerable<ITimeFilter> filters, int value, int defaultValue, out bool overflow)
+        {
+            var previousValue = filters.Select(x => x.Previous(value)).Where(x => x < value).Max() ?? defaultValue;
+            overflow = previousValue >= value;
+            return previousValue;
+        }
+
         private DateTime MinDate(DateTime newValue, DateTime endValue)
         {
             return newValue >= endValue ? endValue : newValue;
+        }
+
+        private DateTime MaxDate(DateTime newValue, DateTime endValue)
+        {
+            return newValue <= endValue ? endValue : newValue;
         }
 
         private DateTime InternalGetNextOccurence(DateTime baseValue, DateTime endValue)
@@ -163,6 +186,99 @@ namespace NCrontab.Advanced
             }
 
             return MinDate(newValue, endValue);
+        }
+
+        private DateTime InternalGetPreviousOccurence(DateTime baseValue, DateTime endValue)
+        {
+            var newValue = baseValue;
+            var overflow = true;
+
+            var isSecondFormat = Format == CronStringFormat.WithSeconds || Format == CronStringFormat.WithSecondsAndYears;
+            var isYearFormat = Format == CronStringFormat.WithYears || Format == CronStringFormat.WithSecondsAndYears;
+
+            // First things first - trim off any time components we don't need
+            newValue = newValue.AddMilliseconds(-newValue.Millisecond);
+            if (!isSecondFormat) newValue = newValue.AddSeconds(-newValue.Second);
+
+            var minuteFilters = Filters[CrontabFieldKind.Minute].Where(x => x is ITimeFilter).Cast<ITimeFilter>().ToList();
+            var hourFilters = Filters[CrontabFieldKind.Hour].Where(x => x is ITimeFilter).Cast<ITimeFilter>().ToList();
+
+            var lastSecondValue = newValue.Second;
+            var lastMinuteValue = minuteFilters.Select(x => x.Last()).Max();
+            var lastHourValue = hourFilters.Select(x => x.Last()).Max();
+
+            var newSeconds = newValue.Second;
+            if (isSecondFormat)
+            {
+                var secondFilters = Filters[CrontabFieldKind.Second].Where(x => x is ITimeFilter).Cast<ITimeFilter>().ToList();
+                lastSecondValue = secondFilters.Select(x => x.Last()).Max();
+                newSeconds = Decrement(secondFilters, newValue.Second, lastSecondValue, out overflow);
+                newValue = new DateTime(newValue.Year, newValue.Month, newValue.Day, newValue.Hour, newValue.Minute, newSeconds);
+                if (!overflow && !IsMatch(newValue))
+                {
+                    newSeconds = lastSecondValue;
+                    newValue = new DateTime(newValue.Year, newValue.Month, newValue.Day, newValue.Hour, newValue.Minute, newSeconds);
+                    overflow = true;
+                }
+                if (!overflow) return MaxDate(newValue, endValue);
+            }
+
+            var newMinutes = Decrement(minuteFilters, newValue.Minute + (overflow ? 0 : 1), lastMinuteValue, out overflow);
+            newValue = new DateTime(newValue.Year, newValue.Month, newValue.Day, newValue.Hour, newMinutes, overflow ? lastSecondValue : newSeconds);
+            if (!overflow && !IsMatch(newValue))
+            {
+                newSeconds = lastSecondValue;
+                newMinutes = lastMinuteValue;
+                newValue = new DateTime(newValue.Year, newValue.Month, newValue.Day, newValue.Hour, newMinutes, lastSecondValue);
+                overflow = true;
+            }
+            if (!overflow) return MaxDate(newValue, endValue);
+
+            var newHours = Decrement(hourFilters, newValue.Hour + (overflow ? 0 : 1), lastHourValue, out overflow);
+            newValue = new DateTime(newValue.Year, newValue.Month, newValue.Day, newHours,
+                overflow ? lastMinuteValue : newMinutes,
+                overflow ? lastSecondValue : newSeconds);
+
+            if (!overflow && !IsMatch(newValue))
+            {
+                newValue = new DateTime(newValue.Year, newValue.Month, newValue.Day, lastHourValue, lastMinuteValue, lastSecondValue);
+                overflow = true;
+            }
+
+            if (!overflow) return MaxDate(newValue, endValue);
+
+            List<ITimeFilter> yearFilters = null;
+            if (isYearFormat) yearFilters = Filters[CrontabFieldKind.Year].Where(x => x is ITimeFilter).Cast<ITimeFilter>().ToList();
+
+            // Sooo, this is where things get more complicated.
+            // Since the filtering of days relies on what month/year you're in
+            // (for weekday/nth day filters), we'll only increment the day, and
+            // check all day/month/year filters.  Might be a litle slow, but we
+            // won't miss any days that way.
+
+            // Also, if we increment to the next day, we need to set the hour, minute and second
+            // fields to their "last" values, since that would be the earliest they'd run.  We
+            // only have to do this after the initial AddDays call.  FYI - they're already at their
+            // last values if overflowHour = True.  :-)
+
+            // This feels so dirty.  This is to catch the odd case where you specify
+            // 12/31/9999 23:59:59.999 as your end date, and you don't have any matches,
+            // so it reaches the max value of DateTime and throws an exception.
+            try { newValue = newValue.AddDays(-1); } catch { return endValue; }
+
+            while (!(IsMatch(newValue, CrontabFieldKind.Day) && IsMatch(newValue, CrontabFieldKind.DayOfWeek) && IsMatch(newValue, CrontabFieldKind.Month) && (!isYearFormat || IsMatch(newValue, CrontabFieldKind.Year))))
+            {
+                if (newValue <= endValue) return MaxDate(newValue, endValue);
+
+                // In instances where the year is filtered, this will speed up the path to get to endValue
+                // (without having to actually go to endValue)
+                if (isYearFormat && yearFilters.Select(x => x.Next(newValue.Year - 1)).All(x => x == null)) return endValue;
+
+                // Ugh...have to do the try/catch again...
+                try { newValue = newValue.AddDays(-1); } catch { return endValue; }
+            }
+
+            return MaxDate(newValue, endValue);
         }
 
         public bool IsMatch(DateTime value)

--- a/NCrontab.Advanced/CrontabSchedule.cs
+++ b/NCrontab.Advanced/CrontabSchedule.cs
@@ -70,6 +70,15 @@ namespace NCrontab.Advanced
             }
         }
 
+        public IEnumerable<DateTime> GetPreviousOccurrences(DateTime baseTime, DateTime endTime)
+        {
+            for (var occurrence = GetPreviousOccurrence(baseTime, endTime); 
+                occurrence > endTime; 
+                occurrence = GetPreviousOccurrence(occurrence, endTime))
+            {
+                yield return occurrence;
+            }
+        }
 
         private int Increment(IEnumerable<ITimeFilter> filters, int value, int defaultValue, out bool overflow)
         {

--- a/NCrontab.Advanced/Filters/AnyFilter.cs
+++ b/NCrontab.Advanced/Filters/AnyFilter.cs
@@ -46,6 +46,20 @@ namespace NCrontab.Advanced.Filters
             return newValue;
         }
 
+        public int? Previous(int value)
+        {
+            var min = Constants.MinimumDateTimeValues[Kind];
+            if (Kind == CrontabFieldKind.Day
+                || Kind == CrontabFieldKind.Month
+                || Kind == CrontabFieldKind.DayOfWeek)
+                throw new CrontabException("Cannot call Next for Day, Month or DayOfWeek types");
+
+            var newValue = (int?)value - 1;
+            if (newValue < min) newValue = null;
+
+            return newValue;
+        }
+
         public int First()
         {
             if (Kind == CrontabFieldKind.Day
@@ -54,6 +68,16 @@ namespace NCrontab.Advanced.Filters
                 throw new CrontabException("Cannot call First for Day, Month or DayOfWeek types");
 
             return 0;
+        }
+
+        public int Last()
+        {
+            if (Kind == CrontabFieldKind.Day
+                || Kind == CrontabFieldKind.Month
+                || Kind == CrontabFieldKind.DayOfWeek)
+                throw new CrontabException("Cannot call Last for Day, Month or DayOfWeek types");
+
+            return Constants.MaximumDateTimeValues[Kind];
         }
 
         public override string ToString()

--- a/NCrontab.Advanced/Filters/SpecificFilter.cs
+++ b/NCrontab.Advanced/Filters/SpecificFilter.cs
@@ -72,7 +72,17 @@ namespace NCrontab.Advanced.Filters
             return SpecificValue;
         }
 
+        public virtual int? Previous(int value)
+        {
+            return SpecificValue;
+        }
+
         public int First()
+        {
+            return SpecificValue;
+        }
+
+        public int Last()
         {
             return SpecificValue;
         }

--- a/NCrontab.Advanced/Filters/SpecificYearFilter.cs
+++ b/NCrontab.Advanced/Filters/SpecificYearFilter.cs
@@ -24,5 +24,13 @@ namespace NCrontab.Advanced.Filters
 
             return null;
         }
+
+        public override int? Previous(int value)
+        {
+            if (value > SpecificValue)
+                return SpecificValue;
+
+            return null;
+        }
     }
 }

--- a/NCrontab.Advanced/Filters/StepFilter.cs
+++ b/NCrontab.Advanced/Filters/StepFilter.cs
@@ -21,6 +21,8 @@ namespace NCrontab.Advanced.Filters
 
         private int? FirstCache { get; set; }
 
+        private int? LastCache { get; set; }
+
         /// <summary>
         /// Returns a list of specific filters that represents this step filter
         /// </summary>
@@ -105,6 +107,24 @@ namespace NCrontab.Advanced.Filters
             return newValue;
         }
 
+        public int? Previous(int value)
+        {
+            if (Kind == CrontabFieldKind.Day
+                || Kind == CrontabFieldKind.Month
+                || Kind == CrontabFieldKind.DayOfWeek)
+                throw new CrontabException("Cannot call Previous for Day, Month or DayOfWeek types");
+
+            var min = Constants.MinimumDateTimeValues[Kind];
+
+            var newValue = (int?)value - 1;
+            while (newValue > min && !IsMatch(newValue.Value))
+                newValue--;
+
+            if (newValue <= min) newValue = null;
+
+            return newValue;
+        }
+
         public int First()
         {
             if (FirstCache.HasValue) return FirstCache.Value;
@@ -127,6 +147,31 @@ namespace NCrontab.Advanced.Filters
                 );
 
             FirstCache = newValue;
+            return newValue;
+        }
+
+        public int Last()
+        {
+            if (LastCache.HasValue) return LastCache.Value;
+
+            if (Kind == CrontabFieldKind.Day
+                || Kind == CrontabFieldKind.Month
+                || Kind == CrontabFieldKind.DayOfWeek)
+                throw new CrontabException("Cannot call Last for Day, Month or DayOfWeek types");
+
+            var min = Constants.MinimumDateTimeValues[Kind];
+
+            var newValue = Constants.MaximumDateTimeValues[Kind];
+            while (newValue > min && !IsMatch(newValue))
+                newValue--;
+
+            if (newValue < min)
+                throw new CrontabException(string.Format("Next value for {0} on field {1} could not be found!",
+                    this.ToString(),
+                    Enum.GetName(typeof(CrontabFieldKind), Kind))
+                );
+
+            LastCache = newValue;
             return newValue;
         }
 

--- a/NCrontab.Advanced/Filters/StepFilter.cs
+++ b/NCrontab.Advanced/Filters/StepFilter.cs
@@ -102,7 +102,7 @@ namespace NCrontab.Advanced.Filters
             while (newValue < max && !IsMatch(newValue.Value))
                 newValue++;
 
-            if (newValue >= max) newValue = null;
+            if (newValue > max) newValue = null;
 
             return newValue;
         }
@@ -120,7 +120,7 @@ namespace NCrontab.Advanced.Filters
             while (newValue > min && !IsMatch(newValue.Value))
                 newValue--;
 
-            if (newValue <= min) newValue = null;
+            if (newValue < min) newValue = null;
 
             return newValue;
         }

--- a/NCrontab.Advanced/Interfaces/ITimeFilter.cs
+++ b/NCrontab.Advanced/Interfaces/ITimeFilter.cs
@@ -8,6 +8,8 @@ namespace NCrontab.Advanced.Interfaces
     interface ITimeFilter
     {
         int? Next(int value);
+        int? Previous(int value);
         int First();
+        int Last();
     }
 }

--- a/build.cake
+++ b/build.cake
@@ -34,7 +34,7 @@ Setup(context =>
     });
 
 
-    nugetVersion = gitVersionInfo.MajorMinorPatch + "-" + gitVersionInfo.PreReleaseLabel + gitVersionInfo.CommitsSinceVersionSourcePadded;
+    nugetVersion = gitVersionInfo.NuGetVersion;
 
     if(BuildSystem.IsRunningOnTeamCity)
         BuildSystem.TeamCity.SetBuildNumber(nugetVersion);
@@ -45,7 +45,7 @@ Setup(context =>
 
 Teardown(context =>
 {
-    Information("Finished running tasks.");
+    Information("Finished running tasks for build v{0}", nugetVersion);
 });
 
 //////////////////////////////////////////////////////////////////////

--- a/build.cake
+++ b/build.cake
@@ -119,6 +119,7 @@ Task("Pack")
             MSBuildSettings = msBuildSettings
         });
     });
+    
 
 Task("Default")
     .IsDependentOn("Pack");

--- a/build.cake
+++ b/build.cake
@@ -1,0 +1,129 @@
+//////////////////////////////////////////////////////////////////////
+// TOOLS
+//////////////////////////////////////////////////////////////////////
+#tool "nuget:?package=GitVersion.CommandLine&version=4.0.0"
+#addin "Cake.FileHelpers"
+#addin "Cake.ExtendedNuGet"
+
+using Path = System.IO.Path;
+
+//////////////////////////////////////////////////////////////////////
+// ARGUMENTS
+//////////////////////////////////////////////////////////////////////
+var target = Argument("target", "Default");
+var configuration = Argument("configuration", "Release");
+var solutionFile = "./NCrontab.Advanced.sln";
+var assemblyInfoFile = "./NCrontab.Advanced/Properties/AssemblyInfo.cs";
+
+///////////////////////////////////////////////////////////////////////////////
+// GLOBAL VARIABLES
+///////////////////////////////////////////////////////////////////////////////
+var artifactsDir = "./build/target/";
+var tempDir = "./build/temp";
+
+GitVersion gitVersionInfo;
+string nugetVersion;
+
+///////////////////////////////////////////////////////////////////////////////
+// SETUP / TEARDOWN
+///////////////////////////////////////////////////////////////////////////////
+Setup(context =>
+{
+    gitVersionInfo = GitVersion(new GitVersionSettings {
+        OutputType = GitVersionOutput.Json
+    });
+
+
+    nugetVersion = gitVersionInfo.MajorMinorPatch + "-" + gitVersionInfo.PreReleaseLabel + gitVersionInfo.CommitsSinceVersionSourcePadded;
+
+    if(BuildSystem.IsRunningOnTeamCity)
+        BuildSystem.TeamCity.SetBuildNumber(nugetVersion);
+
+    Information("Building NCrontab.Advanced v{0}", nugetVersion);
+    Information("Informational Version {0}", gitVersionInfo.InformationalVersion);
+});
+
+Teardown(context =>
+{
+    Information("Finished running tasks.");
+});
+
+//////////////////////////////////////////////////////////////////////
+//  PRIVATE TASKS
+//////////////////////////////////////////////////////////////////////
+
+Task("Clean")
+    .Does(() =>
+{
+    CleanDirectory(artifactsDir);
+	CleanDirectory(tempDir);
+    CleanDirectories("./**/bin");
+    CleanDirectories("./**/obj");
+    CleanDirectories("./Package");
+    CleanDirectories("./**/TestResults");
+});
+
+Task("Restore")
+    .IsDependentOn("Clean")
+    .Does(() => {
+        NuGetRestore(solutionFile);
+    });
+
+Task("SetVersion")
+   .Does(() => {
+       ReplaceRegexInFiles(assemblyInfoFile, 
+                           "(?<=AssemblyVersion\\(\")(.+?)(?=\"\\))", 
+                           gitVersionInfo.MajorMinorPatch);
+       ReplaceRegexInFiles(assemblyInfoFile, 
+                           "(?<=AssemblyFileVersion\\(\")(.+?)(?=\"\\))", 
+                           gitVersionInfo.MajorMinorPatch);
+   });
+
+Task("Build")
+    .IsDependentOn("SetVersion")
+    .IsDependentOn("Restore")
+    .IsDependentOn("Clean")
+    .Does(() =>
+    {
+        MSBuild(solutionFile, settings => settings
+			.SetConfiguration(configuration)
+            .WithProperty("Version", nugetVersion)
+			.WithProperty("PackageVersion", nugetVersion)
+			.WithProperty("FileVersion", nugetVersion)
+			.WithTarget("Build"));
+    });
+
+Task("UnitTests")
+    .IsDependentOn("Build")
+    .Does(() =>
+    {
+        //NCrontab.Advanced.Tests/bin/Release/NCrontab.Advanced.Tests.dll
+        MSTest("./NCrontab.Advanced.Tests/**/NCrontab.Advanced.Tests.dll");
+    });
+
+Task("Pack")
+    .IsDependentOn("UnitTests")
+    .Does(() =>
+    {
+        DotNetCoreMSBuildSettings msBuildSettings = new DotNetCoreMSBuildSettings()
+            .WithProperty("Version", nugetVersion)
+            .WithProperty("AssemblyVersion", nugetVersion)
+            .WithProperty("FileVersion", nugetVersion);
+
+        DotNetCorePack("NCrontab.Advanced/NCrontab.Advanced.csproj", new DotNetCorePackSettings {
+            Configuration = configuration,
+            OutputDirectory = "./Package",
+            NoBuild = true,
+            NoRestore = true,
+            IncludeSymbols = false,
+            MSBuildSettings = msBuildSettings
+        });
+    });
+
+Task("Default")
+    .IsDependentOn("Pack");
+
+//////////////////////////////////////////////////////////////////////
+// EXECUTION
+//////////////////////////////////////////////////////////////////////
+RunTarget(target);

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,24 @@
+@ECHO OFF
+REM see http://joshua.poehls.me/powershell-batch-file-wrapper/
+
+SET SCRIPTNAME=%~d0%~p0%~n0.ps1
+SET ARGS=%*
+IF [%1] NEQ [] GOTO ESCAPE_ARGS
+
+:POWERSHELL
+PowerShell.exe -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Unrestricted -Command "& { $ErrorActionPreference = 'Stop'; & '%SCRIPTNAME%' @args; EXIT $LASTEXITCODE }" %ARGS%
+EXIT /B %ERRORLEVEL%
+
+:ESCAPE_ARGS
+SET ARGS=%ARGS:"=\"%
+SET ARGS=%ARGS:`=``%
+SET ARGS=%ARGS:'=`'%
+SET ARGS=%ARGS:$=`$%
+SET ARGS=%ARGS:{=`}%
+SET ARGS=%ARGS:}=`}%
+SET ARGS=%ARGS:(=`(%
+SET ARGS=%ARGS:)=`)%
+SET ARGS=%ARGS:,=`,%
+SET ARGS=%ARGS:^%=%
+
+GOTO POWERSHELL

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,256 @@
+##########################################################################
+# This is the Cake bootstrapper script for PowerShell.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
+
+<#
+
+.SYNOPSIS
+This is a Powershell script to bootstrap a Cake build.
+
+.DESCRIPTION
+This Powershell script will download NuGet if missing, restore NuGet tools (including Cake)
+and execute your Cake build script with the parameters you provide.
+
+.PARAMETER Script
+The build script to execute.
+.PARAMETER Target
+The build script target to run.
+.PARAMETER Configuration
+The build configuration to use.
+.PARAMETER Verbosity
+Specifies the amount of information to be displayed.
+.PARAMETER ShowDescription
+Shows description about tasks.
+.PARAMETER DryRun
+Performs a dry run.
+.PARAMETER SkipToolPackageRestore
+Skips restoring of packages.
+.PARAMETER ScriptArgs
+Remaining arguments are added here.
+
+.LINK
+https://cakebuild.net
+
+#>
+
+[CmdletBinding()]
+Param(
+    [string]$Script = "build.cake",
+    [string]$Target,
+    [string]$Configuration,
+    [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
+    [string]$Verbosity,
+    [switch]$ShowDescription,
+    [Alias("WhatIf", "Noop")]
+    [switch]$DryRun,
+    [switch]$SkipToolPackageRestore,
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$ScriptArgs
+)
+
+# Attempt to set highest encryption available for SecurityProtocol.
+# PowerShell will not set this by default (until maybe .NET 4.6.x). This
+# will typically produce a message for PowerShell v2 (just an info
+# message though)
+try {
+    # Set TLS 1.2 (3072), then TLS 1.1 (768), then TLS 1.0 (192), finally SSL 3.0 (48)
+    # Use integers because the enumeration values for TLS 1.2 and TLS 1.1 won't
+    # exist in .NET 4.0, even though they are addressable if .NET 4.5+ is
+    # installed (.NET 4.5 is an in-place upgrade).
+    # PowerShell Core already has support for TLS 1.2 so we can skip this if running in that.
+    if (-not $IsCoreCLR) {
+        [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48
+    }
+  } catch {
+    Write-Output 'Unable to set PowerShell to use TLS 1.2 and TLS 1.1 due to old .NET Framework installed. If you see underlying connection closed or trust errors, you may need to upgrade to .NET Framework 4.5+ and PowerShell v3'
+  }
+
+[Reflection.Assembly]::LoadWithPartialName("System.Security") | Out-Null
+function MD5HashFile([string] $filePath)
+{
+    if ([string]::IsNullOrEmpty($filePath) -or !(Test-Path $filePath -PathType Leaf))
+    {
+        return $null
+    }
+
+    [System.IO.Stream] $file = $null;
+    [System.Security.Cryptography.MD5] $md5 = $null;
+    try
+    {
+        $md5 = [System.Security.Cryptography.MD5]::Create()
+        $file = [System.IO.File]::OpenRead($filePath)
+        return [System.BitConverter]::ToString($md5.ComputeHash($file))
+    }
+    finally
+    {
+        if ($file -ne $null)
+        {
+            $file.Dispose()
+        }
+    }
+}
+
+function GetProxyEnabledWebClient
+{
+    $wc = New-Object System.Net.WebClient
+    $proxy = [System.Net.WebRequest]::GetSystemWebProxy()
+    $proxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials
+    $wc.Proxy = $proxy
+    return $wc
+}
+
+Write-Host "Preparing to run build script..."
+
+if(!$PSScriptRoot){
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+
+$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
+$MODULES_DIR = Join-Path $TOOLS_DIR "Modules"
+$NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
+$CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
+$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+$PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
+$PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
+$ADDINS_PACKAGES_CONFIG = Join-Path $ADDINS_DIR "packages.config"
+$MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
+
+# Make sure tools folder exists
+if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
+    Write-Verbose -Message "Creating tools directory..."
+    New-Item -Path $TOOLS_DIR -Type Directory | Out-Null
+}
+
+# Make sure that packages.config exist.
+if (!(Test-Path $PACKAGES_CONFIG)) {
+    Write-Verbose -Message "Downloading packages.config..."
+    try {
+        $wc = GetProxyEnabledWebClient
+        $wc.DownloadFile("https://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG)
+    } catch {
+        Throw "Could not download packages.config."
+    }
+}
+
+# Try find NuGet.exe in path if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Trying to find nuget.exe in PATH..."
+    $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_ -PathType Container) }
+    $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
+    if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
+        Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
+        $NUGET_EXE = $NUGET_EXE_IN_PATH.FullName
+    }
+}
+
+# Try download NuGet.exe if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Downloading NuGet.exe..."
+    try {
+        $wc = GetProxyEnabledWebClient
+        $wc.DownloadFile($NUGET_URL, $NUGET_EXE)
+    } catch {
+        Throw "Could not download NuGet.exe."
+    }
+}
+
+# Save nuget.exe path to environment to be available to child processed
+$env:NUGET_EXE = $NUGET_EXE
+$env:NUGET_EXE_INVOCATION = if ($IsLinux -or $IsMacOS) {
+    "mono `"$NUGET_EXE`""
+} else {
+    "`"$NUGET_EXE`""
+}
+
+# Restore tools from NuGet?
+if(-Not $SkipToolPackageRestore.IsPresent) {
+    Push-Location
+    Set-Location $TOOLS_DIR
+
+    # Check for changes in packages.config and remove installed tools if true.
+    [string] $md5Hash = MD5HashFile $PACKAGES_CONFIG
+    if((!(Test-Path $PACKAGES_CONFIG_MD5)) -Or
+    ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
+        Write-Verbose -Message "Missing or changed package.config hash..."
+        Get-ChildItem -Exclude packages.config,nuget.exe,Cake.Bakery |
+        Remove-Item -Recurse -Force
+    }
+
+    Write-Verbose -Message "Restoring tools from NuGet..."
+    
+    $NuGetOutput = Invoke-Expression "& $env:NUGET_EXE_INVOCATION install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occurred while restoring NuGet tools."
+    }
+    else
+    {
+        $md5Hash | Out-File $PACKAGES_CONFIG_MD5 -Encoding "ASCII"
+    }
+    Write-Verbose -Message ($NuGetOutput | Out-String)
+
+    Pop-Location
+}
+
+# Restore addins from NuGet
+if (Test-Path $ADDINS_PACKAGES_CONFIG) {
+    Push-Location
+    Set-Location $ADDINS_DIR
+
+    Write-Verbose -Message "Restoring addins from NuGet..."
+    $NuGetOutput = Invoke-Expression "& $env:NUGET_EXE_INVOCATION install -ExcludeVersion -OutputDirectory `"$ADDINS_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occurred while restoring NuGet addins."
+    }
+
+    Write-Verbose -Message ($NuGetOutput | Out-String)
+
+    Pop-Location
+}
+
+# Restore modules from NuGet
+if (Test-Path $MODULES_PACKAGES_CONFIG) {
+    Push-Location
+    Set-Location $MODULES_DIR
+
+    Write-Verbose -Message "Restoring modules from NuGet..."
+    $NuGetOutput = Invoke-Expression "& $env:NUGET_EXE_INVOCATION install -ExcludeVersion -OutputDirectory `"$MODULES_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occurred while restoring NuGet modules."
+    }
+
+    Write-Verbose -Message ($NuGetOutput | Out-String)
+
+    Pop-Location
+}
+
+# Make sure that Cake has been installed.
+if (!(Test-Path $CAKE_EXE)) {
+    Throw "Could not find Cake.exe at $CAKE_EXE"
+}
+
+$CAKE_EXE_INVOCATION = if ($IsLinux -or $IsMacOS) {
+    "mono `"$CAKE_EXE`""
+} else {
+    "`"$CAKE_EXE`""
+}
+
+ # Build an array (not a string) of Cake arguments to be joined later
+$cakeArguments = @()
+if ($Script) { $cakeArguments += "`"$Script`"" }
+if ($Target) { $cakeArguments += "-target=`"$Target`"" }
+if ($Configuration) { $cakeArguments += "-configuration=$Configuration" }
+if ($Verbosity) { $cakeArguments += "-verbosity=$Verbosity" }
+if ($ShowDescription) { $cakeArguments += "-showdescription" }
+if ($DryRun) { $cakeArguments += "-dryrun" }
+$cakeArguments += $ScriptArgs
+
+# Start Cake
+Write-Host "Running build script..."
+Invoke-Expression "& $CAKE_EXE_INVOCATION $($cakeArguments -join " ")"
+exit $LASTEXITCODE


### PR DESCRIPTION
In the `tr-TR` culture, the letter `i` is capitalized as `İ`. This causes a problem when using `Fri` as a day of week value.

Since this library only accepts English weekdays, it's safe just to use the invariant culture.