### PR TITLE
(fix) short circuit range filter loops

### DIFF
--- a/NCrontab.Advanced/Filters/RangeFilter.cs
+++ b/NCrontab.Advanced/Filters/RangeFilter.cs
@@ -100,7 +100,8 @@ namespace NCrontab.Advanced.Filters
             while (newValue < max && !IsMatch(newValue.Value))
             {
                 // short circuit, `IsMatch` can never be true
-                if (newValue > End) return null;
+                if (newValue > End)
+                    newValue = max;
                 newValue++;
             }
 

--- a/NCrontab.Advanced/Filters/RangeFilter.cs
+++ b/NCrontab.Advanced/Filters/RangeFilter.cs
@@ -122,7 +122,12 @@ namespace NCrontab.Advanced.Filters
 
             var newValue = 0;
             while (newValue < max && !IsMatch(newValue))
+            {
+                // short circuit, `IsMatch` can never be true
+                if (newValue > End)
+                    newValue = max;
                 newValue++;
+            }
 
             if (newValue > max)
                 throw new CrontabException(string.Format("Next value for {0} on field {1} could not be found!",

--- a/NCrontab.Advanced/Filters/RangeFilter.cs
+++ b/NCrontab.Advanced/Filters/RangeFilter.cs
@@ -98,7 +98,11 @@ namespace NCrontab.Advanced.Filters
 
             var newValue = (int?) value + 1;
             while (newValue < max && !IsMatch(newValue.Value))
+            {
+                // short circuit, `IsMatch` can never be true
+                if (newValue > End) return null;
                 newValue++;
+            }
 
             if (newValue > max) newValue = null;
 


### PR DESCRIPTION
if `newValue` is already bigger than `End` then `IsMatch` will never return `true` so we iterate until `max`.